### PR TITLE
Add settings server actions

### DIFF
--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -1,29 +1,38 @@
-'use client';
+import { redirect } from 'next/navigation';
 
-import { useAuth } from '@/features/auth';
-import { SettingsScreen } from '@/features/settings';
+import { signOut } from '@/auth';
+import { getSettings, updateSettings, SettingsScreen } from '@/features/settings';
 
-import type { UserSettings } from '@/features/settings';
+import type { NotificationPreferences } from '@/features/settings';
+
+/** Server action wrapper for sign out with redirect. */
+async function handleSignOut() {
+  'use server';
+  await signOut({ redirectTo: '/signin' });
+}
+
+/** Server action wrapper to persist a single notification toggle. */
+async function handleToggle(key: keyof NotificationPreferences, value: boolean) {
+  'use server';
+  await updateSettings({ [key]: value });
+}
 
 /**
  * Settings page — user preferences and Tesla account linking.
- * Profile name/email come from the session; other settings are still mock.
+ * Fetches real settings from the database via server action.
  */
-export default function SettingsPage() {
-  const { user, signOut } = useAuth();
+export default async function SettingsPage() {
+  const settings = await getSettings();
 
-  const settings: UserSettings = {
-    name: user?.name ?? '',
-    email: user?.email ?? '',
-    teslaLinked: false,
-    teslaVehicleName: undefined,
-    notifications: {
-      driveStarted: true,
-      driveCompleted: true,
-      chargingComplete: false,
-      viewerJoined: true,
-    },
-  };
+  if (!settings) {
+    redirect('/signin');
+  }
 
-  return <SettingsScreen settings={settings} onSignOut={signOut} />;
+  return (
+    <SettingsScreen
+      settings={settings}
+      onSignOut={handleSignOut}
+      onToggle={handleToggle}
+    />
+  );
 }

--- a/src/features/settings/api/actions.ts
+++ b/src/features/settings/api/actions.ts
@@ -1,0 +1,101 @@
+'use server';
+
+import { auth } from '@/auth';
+import { prisma } from '@/lib/prisma';
+
+import type { UserSettings, NotificationPreferences } from '../types';
+
+/**
+ * Map from NotificationPreferences keys to Prisma Settings column names.
+ */
+const NOTIFICATION_COLUMN_MAP: Record<keyof NotificationPreferences, string> = {
+  driveStarted: 'notifyDriveStarted',
+  driveCompleted: 'notifyDriveCompleted',
+  chargingComplete: 'notifyChargingComplete',
+  viewerJoined: 'notifyViewerJoined',
+};
+
+/**
+ * Fetch the current user's settings, creating defaults if none exist.
+ * Returns null if the user is not authenticated.
+ */
+export async function getSettings(): Promise<UserSettings | null> {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    return null;
+  }
+
+  const userId = session.user.id;
+
+  const settings = await prisma.settings.upsert({
+    where: { userId },
+    create: { userId },
+    update: {},
+  });
+
+  return {
+    name: session.user.name ?? '',
+    email: session.user.email ?? '',
+    teslaLinked: settings.teslaLinked,
+    teslaVehicleName: settings.teslaVehicleName ?? undefined,
+    notifications: {
+      driveStarted: settings.notifyDriveStarted,
+      driveCompleted: settings.notifyDriveCompleted,
+      chargingComplete: settings.notifyChargingComplete,
+      viewerJoined: settings.notifyViewerJoined,
+    },
+  };
+}
+
+/**
+ * Update the current user's notification preferences.
+ * Accepts a partial object so callers can update individual toggles.
+ */
+export async function updateSettings(
+  prefs: Partial<NotificationPreferences>,
+): Promise<void> {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    throw new Error('Not authenticated');
+  }
+
+  const data: Record<string, boolean> = {};
+
+  for (const [key, value] of Object.entries(prefs)) {
+    const column = NOTIFICATION_COLUMN_MAP[key as keyof NotificationPreferences];
+    if (column && typeof value === 'boolean') {
+      data[column] = value;
+    }
+  }
+
+  if (Object.keys(data).length === 0) {
+    return;
+  }
+
+  await prisma.settings.upsert({
+    where: { userId: session.user.id },
+    create: { userId: session.user.id, ...data },
+    update: data,
+  });
+}
+
+/**
+ * Unlink the Tesla account for the current user.
+ * Sets teslaLinked to false and clears the vehicle name.
+ * Full Tesla unlink with vehicle data deletion is a TODO for issue #11.
+ */
+export async function unlinkTesla(): Promise<void> {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    throw new Error('Not authenticated');
+  }
+
+  await prisma.settings.upsert({
+    where: { userId: session.user.id },
+    create: { userId: session.user.id, teslaLinked: false, teslaVehicleName: null },
+    update: { teslaLinked: false, teslaVehicleName: null },
+  });
+}

--- a/src/features/settings/components/SettingsScreen.tsx
+++ b/src/features/settings/components/SettingsScreen.tsx
@@ -12,6 +12,8 @@ export interface SettingsScreenProps {
   settings: UserSettings;
   /** Callback to sign the user out. */
   onSignOut: () => void;
+  /** Optional callback when a notification toggle changes. */
+  onToggle?: (key: keyof UserSettings['notifications'], value: boolean) => void;
 }
 
 /** Notification toggle item shape. */
@@ -31,11 +33,13 @@ const NOTIFICATION_ITEMS: NotificationItem[] = [
  * Settings screen — profile info, Tesla link status, notification toggles, sign out.
  * Matches ui-mocks/src/pages/Settings.tsx pixel-for-pixel.
  */
-export function SettingsScreen({ settings, onSignOut }: SettingsScreenProps) {
+export function SettingsScreen({ settings, onSignOut, onToggle }: SettingsScreenProps) {
   const [notifications, setNotifications] = useState(settings.notifications);
 
   const handleToggle = (key: keyof UserSettings['notifications']) => {
-    setNotifications((prev) => ({ ...prev, [key]: !prev[key] }));
+    const newValue = !notifications[key];
+    setNotifications((prev) => ({ ...prev, [key]: newValue }));
+    onToggle?.(key, newValue);
   };
 
   return (

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -6,5 +6,8 @@
 // Components
 export { SettingsScreen } from './components/SettingsScreen';
 
+// Server actions
+export { getSettings, updateSettings, unlinkTesla } from './api/actions';
+
 // Types
 export type { UserSettings, NotificationPreferences } from './types';


### PR DESCRIPTION
## Summary
- Create `src/features/settings/api/actions.ts` with three server actions: `getSettings()`, `updateSettings()`, and `unlinkTesla()`
- Replace mock/static settings data in the settings page with real database queries via `getSettings()`
- Wire notification toggle persistence through `updateSettings()` server action
- Convert settings page from client component to async server component with proper auth redirect

## Details

### Server Actions (`src/features/settings/api/actions.ts`)
- **`getSettings()`**: Authenticates via `auth()`, upserts a Settings row (creating defaults if needed), and maps Prisma columns to the `UserSettings` interface (pulling `name`/`email` from the session user)
- **`updateSettings(prefs)`**: Accepts `Partial<NotificationPreferences>`, maps keys to Prisma column names (`driveStarted` -> `notifyDriveStarted`, etc.), and upserts the settings row
- **`unlinkTesla()`**: Sets `teslaLinked = false` and clears `teslaVehicleName` (full Tesla data deletion deferred to issue #11)

### Settings Page (`src/app/(main)/settings/page.tsx`)
- Converted from `'use client'` with `useAuth()` + mock data to an async server component
- Calls `getSettings()` for real data, redirects to `/signin` if unauthenticated
- Wraps `signOut` and `updateSettings` as inline server actions passed to `SettingsScreen`

### SettingsScreen Component
- Added optional `onToggle` prop for persisting toggle changes
- `handleToggle` now calls `onToggle?.(key, newValue)` alongside local state update

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes (settings page correctly renders as dynamic `f` route)
- [ ] Manual: Sign in, navigate to /settings, verify profile/notification data loads from DB
- [ ] Manual: Toggle a notification switch, refresh page, verify persistence
- [ ] Manual: Visit /settings while unauthenticated, verify redirect to /signin

> Note: `npm run test` has a pre-existing jsdom ESM compatibility failure (`ERR_REQUIRE_ESM` for `@exodus/bytes/encoding-lite.js`) unrelated to this PR.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)