### PR TITLE
Fix code review workflow: add checkout step

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -22,6 +22,11 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds `actions/checkout@v6` before `anthropics/claude-code-action@v1`
- The action needs a git directory to configure git authentication — without checkout it fails with `fatal: not in a git directory`
- Uses `fetch-depth: 0` for full history access during review

## Test plan

- [ ] After merge, retrigger on PRs #48–#51 to verify reviews post successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)