### PR TITLE
Debug code review workflow: enable full output

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_sticky_comment: true
+          show_full_output: true
           claude_args: |
             --max-turns 15
             --model claude-sonnet-4-6


### PR DESCRIPTION
Temporary: enables `show_full_output: true` on the code review action so we can see the actual Claude Code error. The SDK is crashing with exit code 1 and 0 API cost, meaning it never reaches the Anthropic API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)