### PR TITLE
Switch code review to Claude Code OAuth token

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           show_full_output: true
           claude_args: |


### PR DESCRIPTION
## Summary

- Swaps `anthropic_api_key` → `claude_code_oauth_token` in the code review workflow
- Uses Claude Pro/Max subscription auth instead of Anthropic API billing (which was failing with `billing_error`)

## Setup required

1. Run `claude setup-token` locally to generate the OAuth token
2. Add `CLAUDE_CODE_OAUTH_TOKEN` secret at https://github.com/tnando/my-robo-taxi/settings/secrets/actions
3. Merge this PR, then rebase PRs #48–#51 to trigger reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)