### PR TITLE
Handle missing vehicle sub-states in Tesla mapper

### DIFF
--- a/__tests__/lib/tesla-mapper.test.ts
+++ b/__tests__/lib/tesla-mapper.test.ts
@@ -168,7 +168,7 @@ describe('mapTeslaVehicleToUpsertData', () => {
   it('defaults null speed to 0', () => {
     const parkedData: TeslaVehicleData = {
       ...vehicleData,
-      drive_state: { ...vehicleData.drive_state, speed: null },
+      drive_state: { ...vehicleData.drive_state!, speed: null },
     };
 
     const result = mapTeslaVehicleToUpsertData(listItem, parkedData);
@@ -180,11 +180,30 @@ describe('mapTeslaVehicleToUpsertData', () => {
     const noNameData: TeslaVehicleData = {
       ...vehicleData,
       display_name: null,
-      vehicle_state: { ...vehicleData.vehicle_state, vehicle_name: null },
+      vehicle_state: { ...vehicleData.vehicle_state!, vehicle_name: null },
     };
 
     const result = mapTeslaVehicleToUpsertData(noNameItem, noNameData);
     expect(result.name).toBe('My Tesla');
+  });
+
+  it('handles missing sub-states for asleep vehicles', () => {
+    const asleepData: TeslaVehicleData = {
+      id: 123,
+      vehicle_id: 456,
+      vin: '5YJ3E1EA1PF000001',
+      display_name: 'Sleepy',
+      state: 'asleep',
+    };
+
+    const result = mapTeslaVehicleToUpsertData(listItem, asleepData);
+    expect(result.name).toBe('Sleepy');
+    expect(result.status).toBe('offline');
+    expect(result.speed).toBe(0);
+    expect(result.chargeLevel).toBe(0);
+    expect(result.odometerMiles).toBe(0);
+    expect(result.latitude).toBe(0);
+    expect(result.longitude).toBe(0);
   });
 
   it('defaults null values to 0', () => {

--- a/src/lib/tesla-client.ts
+++ b/src/lib/tesla-client.ts
@@ -62,10 +62,10 @@ export interface TeslaVehicleData {
   vin: string;
   display_name: string | null;
   state: string;
-  drive_state: TeslaDriveState;
-  charge_state: TeslaChargeState;
-  vehicle_state: TeslaVehicleState;
-  climate_state: TeslaClimateState;
+  drive_state?: TeslaDriveState;
+  charge_state?: TeslaChargeState;
+  vehicle_state?: TeslaVehicleState;
+  climate_state?: TeslaClimateState;
 }
 
 // ─── Internal fetch with retry ───────────────────────────────────────────────

--- a/src/lib/tesla-mapper.ts
+++ b/src/lib/tesla-mapper.ts
@@ -83,7 +83,18 @@ export function mapTeslaVehicleToUpsertData(
   listItem: TeslaVehicleListItem,
   vehicleData: TeslaVehicleData,
 ): TeslaVehicleUpsertData {
-  const { drive_state, charge_state, vehicle_state, climate_state } = vehicleData;
+  const drive_state = vehicleData.drive_state ?? {
+    latitude: null, longitude: null, heading: null, speed: null,
+  };
+  const charge_state = vehicleData.charge_state ?? {
+    battery_level: null, battery_range: null, charging_state: null,
+  };
+  const vehicle_state = vehicleData.vehicle_state ?? {
+    odometer: null, vehicle_name: null,
+  };
+  const climate_state = vehicleData.climate_state ?? {
+    inside_temp: null, outside_temp: null,
+  };
   const { model, year } = parseModelFromVin(vehicleData.vin);
 
   return {
@@ -96,8 +107,8 @@ export function mapTeslaVehicleToUpsertData(
     estimatedRange: Math.round(charge_state.battery_range ?? 0),
     status: mapTeslaStateToVehicleStatus(
       vehicleData.state,
-      charge_state.charging_state,
-      drive_state.speed,
+      charge_state.charging_state ?? null,
+      drive_state.speed ?? null,
     ),
     speed: drive_state.speed ?? 0,
     heading: drive_state.heading ?? 0,


### PR DESCRIPTION
## Summary

Closes #62

- **Fix crash** when Tesla Fleet API returns `vehicle_data` without sub-state objects (`drive_state`, `charge_state`, `vehicle_state`, `climate_state`) for asleep/offline vehicles
- **Mark sub-states as optional** in `TeslaVehicleData` type to match real API behavior
- **Default to safe null values** so the mapper gracefully handles partial responses

## Root cause

Vercel logs showed:
```
Failed to sync Tesla vehicle: TypeError: Cannot read properties of undefined (reading 'vehicle_name')
```

The mapper destructured sub-states directly without null checks. When a vehicle is asleep, Tesla omits these objects entirely.

## Test plan

- [x] `npm run typecheck` — no errors
- [x] `npm test` — 255 tests pass (1 new test for asleep vehicle case)
- [x] New test: `handles missing sub-states for asleep vehicles` verifies all fields default correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)