### PR TITLE
Fix Tesla OAuth providerAccountId resolving to "undefined"

### DIFF
--- a/__tests__/lib/tesla.test.ts
+++ b/__tests__/lib/tesla.test.ts
@@ -39,7 +39,7 @@ describe('Tesla constants', () => {
 
   it('exports correct userinfo URL', () => {
     expect(TESLA_USERINFO_URL).toBe(
-      'https://fleet-api.prd.na.vn.cloud.tesla.com/api/1/users/me',
+      'https://auth.tesla.com/oauth2/v3/userinfo',
     );
   });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -43,8 +43,14 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
             },
             userinfo: { url: TESLA_USERINFO_URL },
             profile(profile: Record<string, unknown>) {
+              const sub = profile.sub ?? profile.id;
+              if (!sub) {
+                throw new Error(
+                  'Tesla userinfo response missing user identifier (sub/id)',
+                );
+              }
               return {
-                id: String(profile.sub ?? profile.id),
+                id: String(sub),
                 name: String(profile.full_name ?? profile.name ?? 'Tesla User'),
                 email: String(profile.email ?? ''),
               };

--- a/src/lib/tesla.ts
+++ b/src/lib/tesla.ts
@@ -11,7 +11,7 @@ export const TESLA_AUTH_URL = 'https://auth.tesla.com/oauth2/v3/authorize';
 export const TESLA_TOKEN_URL =
   'https://auth.tesla.com/oauth2/v3/token';
 export const TESLA_USERINFO_URL =
-  'https://fleet-api.prd.na.vn.cloud.tesla.com/api/1/users/me';
+  'https://auth.tesla.com/oauth2/v3/userinfo';
 export const TESLA_AUDIENCE = 'https://fleet-api.prd.na.vn.cloud.tesla.com';
 export const TESLA_ISSUER = 'https://auth.tesla.com/oauth2/v3/nts';
 export const TESLA_SCOPES =


### PR DESCRIPTION
## Summary

- **Root cause**: `TESLA_USERINFO_URL` pointed to the Fleet API endpoint (`/api/1/users/me`) which wraps responses in `{ response: {} }` and has no `sub` or `id` at the top level. `String(profile.sub ?? profile.id)` evaluated to the literal string `"undefined"` for every user.
- **Fix**: Switch to Tesla's proper OIDC userinfo endpoint (`https://auth.tesla.com/oauth2/v3/userinfo`) from their [OpenID Configuration](https://fleet-auth.prd.vn.cloud.tesla.com/oauth2/v3/thirdparty/.well-known/openid-configuration), which returns standard claims including `sub`.
- **Guard**: Added a runtime check that throws if neither `sub` nor `id` is present, preventing silent data corruption.

## Manual steps after merge

1. **Delete corrupted Account records** in Supabase:
   - Delete the row with `providerAccountId: "undefined"` (User #1's broken Tesla link)
   - Delete the row with `providerAccountId: "tesla-dev-account"` (seed data)
2. **Both users re-link** their Tesla accounts via the app
3. **Verify** the new Account records have proper Tesla user IDs as `providerAccountId`

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — all 255 tests pass (updated userinfo URL assertion)
- [x] `npm run build` succeeds

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)