### PR TITLE
Fix unlink Tesla: delete vehicles, confirmation dialog, UI feedback

### DIFF
--- a/__tests__/features/settings/components/SettingsScreen.test.tsx
+++ b/__tests__/features/settings/components/SettingsScreen.test.tsx
@@ -1,9 +1,20 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { SettingsScreen } from '@/features/settings/components/SettingsScreen';
 
 import type { UserSettings } from '@/features/settings/types';
+
+// jsdom doesn't implement HTMLDialogElement.showModal/close
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+});
 
 const baseSettings: UserSettings = {
   name: 'Jane Doe',
@@ -53,12 +64,14 @@ describe('SettingsScreen — Tesla Link/Unlink', () => {
     expect(button.closest('form')).toBeInTheDocument();
   });
 
-  it('renders Unlink as a submit button inside a form', () => {
+  it('renders Unlink as a button that opens a confirmation dialog', async () => {
     renderScreen({ teslaLinked: true, teslaVehicleName: 'Model Y' });
 
     const button = screen.getByRole('button', { name: 'Unlink' });
-    expect(button).toHaveAttribute('type', 'submit');
-    expect(button.closest('form')).toBeInTheDocument();
+    expect(button).toHaveAttribute('type', 'button');
+
+    await userEvent.click(button);
+    expect(screen.getByText('Unlink Tesla account?')).toBeInTheDocument();
   });
 
   it('shows linked vehicle name', () => {

--- a/__tests__/features/settings/components/UnlinkConfirmDialog.test.tsx
+++ b/__tests__/features/settings/components/UnlinkConfirmDialog.test.tsx
@@ -1,0 +1,64 @@
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { UnlinkConfirmDialog } from '@/features/settings/components/UnlinkConfirmDialog';
+
+// jsdom doesn't implement HTMLDialogElement.showModal/close
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+});
+
+describe('UnlinkConfirmDialog', () => {
+  it('renders dialog content when open', () => {
+    render(
+      <UnlinkConfirmDialog open loading={false} onConfirm={vi.fn()} onCancel={vi.fn()} />,
+    );
+
+    expect(screen.getByText('Unlink Tesla account?')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Unlink' })).toBeInTheDocument();
+  });
+
+  it('calls onCancel when Cancel is clicked', async () => {
+    const onCancel = vi.fn();
+    render(
+      <UnlinkConfirmDialog open loading={false} onConfirm={vi.fn()} onCancel={onCancel} />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('calls onConfirm when Unlink is clicked', async () => {
+    const onConfirm = vi.fn();
+    render(
+      <UnlinkConfirmDialog open loading={false} onConfirm={onConfirm} onCancel={vi.fn()} />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Unlink' }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('shows loading text and disables buttons when loading', () => {
+    render(
+      <UnlinkConfirmDialog open loading onConfirm={vi.fn()} onCancel={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('button', { name: /unlinking/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  });
+
+  it('calls showModal when open becomes true', () => {
+    render(
+      <UnlinkConfirmDialog open loading={false} onConfirm={vi.fn()} onCancel={vi.fn()} />,
+    );
+
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+  });
+});

--- a/src/features/settings/api/actions.ts
+++ b/src/features/settings/api/actions.ts
@@ -1,5 +1,7 @@
 'use server';
 
+import { revalidatePath } from 'next/cache';
+
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 
@@ -106,13 +108,15 @@ export async function unlinkTesla(): Promise<void> {
 
   const userId = session.user.id;
 
-  await prisma.account.deleteMany({
-    where: { userId, provider: 'tesla' },
-  });
+  await prisma.$transaction([
+    prisma.vehicle.deleteMany({ where: { userId } }),
+    prisma.account.deleteMany({ where: { userId, provider: 'tesla' } }),
+    prisma.settings.upsert({
+      where: { userId },
+      create: { userId, teslaLinked: false, teslaVehicleName: null },
+      update: { teslaLinked: false, teslaVehicleName: null },
+    }),
+  ]);
 
-  await prisma.settings.upsert({
-    where: { userId },
-    create: { userId, teslaLinked: false, teslaVehicleName: null },
-    update: { teslaLinked: false, teslaVehicleName: null },
-  });
+  revalidatePath('/settings');
 }

--- a/src/features/settings/components/SettingsScreen.tsx
+++ b/src/features/settings/components/SettingsScreen.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 
 import type { UserSettings } from '../types';
 
 import { ToggleSwitch } from './ToggleSwitch';
+import { UnlinkConfirmDialog } from './UnlinkConfirmDialog';
 
 /** Props for the SettingsScreen component. */
 export interface SettingsScreenProps {
@@ -45,11 +46,22 @@ export function SettingsScreen({
   onToggle,
 }: SettingsScreenProps) {
   const [notifications, setNotifications] = useState(settings.notifications);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [unlinkSuccess, setUnlinkSuccess] = useState(false);
+  const [isPending, startTransition] = useTransition();
 
   const handleToggle = (key: keyof UserSettings['notifications']) => {
     const newValue = !notifications[key];
     setNotifications((prev) => ({ ...prev, [key]: newValue }));
     onToggle?.(key, newValue);
+  };
+
+  const handleUnlinkConfirm = () => {
+    startTransition(async () => {
+      await onUnlinkTesla();
+      setShowConfirm(false);
+      setUnlinkSuccess(true);
+    });
   };
 
   return (
@@ -79,24 +91,25 @@ export function SettingsScreen({
           <div className="flex items-center gap-3">
             <div
               className={`w-2 h-2 rounded-full ${
-                settings.teslaLinked ? 'bg-status-driving' : 'bg-text-muted'
+                settings.teslaLinked && !unlinkSuccess ? 'bg-status-driving' : 'bg-text-muted'
               }`}
             />
             <p className="text-text-primary text-sm font-light">
-              {settings.teslaLinked
-                ? `Linked to ${settings.teslaVehicleName ?? 'Tesla'}`
-                : 'Not linked'}
+              {unlinkSuccess
+                ? 'Tesla account unlinked'
+                : settings.teslaLinked
+                  ? `Linked to ${settings.teslaVehicleName ?? 'Tesla'}`
+                  : 'Not linked'}
             </p>
           </div>
-          {settings.teslaLinked ? (
-            <form action={onUnlinkTesla}>
-              <button
-                type="submit"
-                className="text-text-muted text-sm font-light hover:text-red-400 transition-colors"
-              >
-                Unlink
-              </button>
-            </form>
+          {settings.teslaLinked && !unlinkSuccess ? (
+            <button
+              type="button"
+              onClick={() => setShowConfirm(true)}
+              className="text-text-muted text-sm font-light hover:text-red-400 transition-colors"
+            >
+              Unlink
+            </button>
           ) : (
             <form action={onLinkTesla}>
               <button
@@ -109,6 +122,13 @@ export function SettingsScreen({
           )}
         </div>
       </div>
+
+      <UnlinkConfirmDialog
+        open={showConfirm}
+        loading={isPending}
+        onConfirm={handleUnlinkConfirm}
+        onCancel={() => setShowConfirm(false)}
+      />
 
       {/* Notifications */}
       <div className="px-6 mb-10">

--- a/src/features/settings/components/UnlinkConfirmDialog.tsx
+++ b/src/features/settings/components/UnlinkConfirmDialog.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+export interface UnlinkConfirmDialogProps {
+  open: boolean;
+  loading: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function UnlinkConfirmDialog({
+  open,
+  loading,
+  onConfirm,
+  onCancel,
+}: UnlinkConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (open && !dialog.open) {
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onCancel}
+      className="bg-bg-elevated rounded-2xl p-6 max-w-xs w-full backdrop:bg-black/60"
+    >
+      <h2 className="text-text-primary text-base font-semibold mb-2">
+        Unlink Tesla account?
+      </h2>
+      <p className="text-text-muted text-sm font-light mb-6">
+        Your vehicle data will be removed. You can re-link anytime.
+      </p>
+      <div className="flex gap-3 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={loading}
+          className="px-4 py-2 text-sm font-medium text-text-muted hover:text-text-secondary transition-colors rounded-lg disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={loading}
+          className="px-4 py-2 text-sm font-medium text-red-400 hover:text-red-300 bg-red-400/10 hover:bg-red-400/20 transition-colors rounded-lg disabled:opacity-50"
+        >
+          {loading ? 'Unlinking\u2026' : 'Unlink'}
+        </button>
+      </div>
+    </dialog>
+  );
+}


### PR DESCRIPTION
## Summary

- **Vehicles now deleted on unlink** — `unlinkTesla()` was only deleting the Tesla Account record, leaving orphaned Vehicle (and cascaded Drive, TripStop, Invite) records. All three operations now run in a single `$transaction`.
- **Confirmation dialog** — Unlink button opens a native `<dialog>` modal ("Unlink Tesla account?") with Cancel/Unlink actions, preventing accidental unlinking.
- **Loading state** — `useTransition` disables dialog buttons and shows "Unlinking…" while the server action processes.
- **Inline UI feedback** — On success, status dot goes gray, text updates to "Tesla account unlinked", and button switches to "Link" — no page refresh needed. `revalidatePath('/settings')` ensures server state is also refreshed.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test` — 260 tests pass (5 new: UnlinkConfirmDialog + updated SettingsScreen tests)
- [x] `npm run build` — production build succeeds
- [ ] Manual: Settings page → click Unlink → confirm dialog appears
- [ ] Manual: Click Cancel → dialog closes, nothing changes
- [ ] Manual: Click Unlink in dialog → loading state → success message → Link button shown
- [ ] Manual: Verify vehicles are deleted from DB after unlink
- [ ] Manual: Re-link Tesla → vehicles sync back

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)