### PR TITLE
Add location_data endpoint to Tesla vehicle_data API call

### DIFF
--- a/src/lib/tesla-client.ts
+++ b/src/lib/tesla-client.ts
@@ -158,7 +158,7 @@ export async function getVehicleData(
   accessToken: string,
   vehicleId: number,
 ): Promise<TeslaVehicleData> {
-  const endpoints = 'charge_state;drive_state;vehicle_state;climate_state';
+  const endpoints = 'charge_state;climate_state;drive_state;location_data;vehicle_state';
   const res = await fetchWithRetry(
     `${BASE_URL}/api/1/vehicles/${vehicleId}/vehicle_data?endpoints=${endpoints}`,
     { headers: authHeaders(accessToken) },


### PR DESCRIPTION
## Summary

- Tesla Fleet API gates `latitude`/`longitude` behind the `location_data` endpoint, separate from `drive_state`
- Without requesting `location_data`, coordinates are always null → mapper defaults to 0,0 → map shows Austin fallback instead of actual vehicle position
- One-line fix: add `location_data` to the `endpoints` query parameter in `getVehicleData()`

## Root Cause

The `getVehicleData()` call was requesting:
```
endpoints=charge_state;drive_state;vehicle_state;climate_state
```

`drive_state` returns speed/heading/shift_state but **not** latitude/longitude. Location coordinates require the `location_data` endpoint. This is why telemetry (battery, range, temps) worked but the vehicle marker always showed at the Austin default center.

## Change

```diff
- const endpoints = 'charge_state;drive_state;vehicle_state;climate_state';
+ const endpoints = 'charge_state;climate_state;drive_state;location_data;vehicle_state';
```

The `location_data` endpoint populates `drive_state.latitude`/`drive_state.longitude` in the response — no changes needed to response types or mapper.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test` — 264 tests pass
- [x] `npm run build` — production build succeeds
- [ ] Manual: After deploy, vehicle marker should appear at actual GPS coordinates instead of Austin default

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)