### PR TITLE
Fix silent sync failure with structured logging and isolated settings upsert

### DIFF
--- a/__tests__/features/vehicles/api/actions-sync.test.ts
+++ b/__tests__/features/vehicles/api/actions-sync.test.ts
@@ -79,6 +79,8 @@ import { TeslaApiError } from '@/lib/tesla-client';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Suppress sync completion log in tests
+  vi.spyOn(console, 'log').mockImplementation(() => {});
 });
 
 afterEach(() => {
@@ -212,12 +214,41 @@ describe('syncVehiclesFromTesla', () => {
       .mockRejectedValueOnce(new Error('DB error'));
     mockSettingsUpsert.mockResolvedValue({});
 
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const count = await syncVehiclesFromTesla('user-1');
 
     expect(count).toBe(1);
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to sync Tesla vehicle'),
+      expect.stringContaining('[sync] Failed to sync vehicle'),
+      expect.anything(),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('returns synced count even when settings upsert fails', async () => {
+    mockGetTeslaAccessToken.mockResolvedValue('test-token');
+    mockListVehicles.mockResolvedValue([
+      { id: 123, vehicle_id: 456, vin: 'VIN1', display_name: 'Car 1', state: 'online' },
+    ]);
+    mockGetVehicleData.mockResolvedValue({
+      id: 123,
+      vin: 'VIN1',
+      state: 'online',
+      drive_state: {},
+      charge_state: {},
+      vehicle_state: {},
+      climate_state: {},
+    });
+    mockVehicleUpsert.mockResolvedValue({});
+    mockSettingsUpsert.mockRejectedValue(new Error('Settings column missing'));
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const count = await syncVehiclesFromTesla('user-1');
+
+    expect(count).toBe(1);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[sync] Failed to update settings'),
+      expect.stringContaining('user-1'),
       expect.anything(),
     );
     consoleSpy.mockRestore();
@@ -263,17 +294,22 @@ describe('getVehicles', () => {
     expect(mockGetTeslaAccessToken).not.toHaveBeenCalled();
   });
 
-  it('serves cached data when sync fails', async () => {
+  it('serves cached data when sync fails and logs the error', async () => {
     mockAuth.mockResolvedValue(mockSession);
     mockVehicleFindFirst.mockResolvedValue(null);
     mockGetTeslaAccessToken.mockRejectedValue(new Error('Sync boom'));
     mockVehicleFindMany.mockResolvedValue([]);
 
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const result = await getVehicles();
 
     expect(result).toEqual([]);
-    // Sync failure is silently caught — falls through to cached DB data
     expect(mockVehicleFindMany).toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[getVehicles] Sync failed'),
+      expect.anything(),
+    );
+    consoleSpy.mockRestore();
   });
 
   it('returns empty array when not authenticated', async () => {

--- a/src/features/vehicles/api/actions.ts
+++ b/src/features/vehicles/api/actions.ts
@@ -132,8 +132,8 @@ export async function getVehicles(): Promise<Vehicle[]> {
     if (isStale) {
       await syncVehiclesFromTesla(session.user.id);
     }
-  } catch {
-    // Sync failure is expected with invalid/dev tokens — fall through to cached DB data
+  } catch (err) {
+    console.error('[getVehicles] Sync failed, serving cached data:', err);
   }
 
   const prismaVehicles = await prisma.vehicle.findMany({

--- a/src/features/vehicles/api/sync.ts
+++ b/src/features/vehicles/api/sync.ts
@@ -55,6 +55,7 @@ function hasFullData(vehicleData: TeslaVehicleData): boolean {
  * Returns the count of successfully synced vehicles.
  */
 export async function syncVehiclesFromTesla(userId: string): Promise<number> {
+  const startTime = Date.now();
   const accessToken = await getTeslaAccessToken(userId);
   if (!accessToken) return 0;
 
@@ -62,7 +63,7 @@ export async function syncVehiclesFromTesla(userId: string): Promise<number> {
   try {
     teslaVehicles = await teslaListVehicles(accessToken);
   } catch (err) {
-    console.warn('Failed to list Tesla vehicles:', err);
+    console.error('[sync] Failed to list Tesla vehicles for user', userId, err);
     return 0;
   }
   let syncedCount = 0;
@@ -132,18 +133,29 @@ export async function syncVehiclesFromTesla(userId: string): Promise<number> {
       });
       syncedCount++;
     } catch (err) {
-      console.warn(`Failed to sync Tesla vehicle ${listItem.id}:`, err);
+      console.error(`[sync] Failed to sync vehicle ${listItem.id} (step: fetch/upsert):`, err);
     }
   }
 
-  // Update virtual key pairing status so the UI can show setup prompts
+  // Update virtual key pairing status so the UI can show setup prompts.
+  // Isolated from the vehicle sync so a settings error doesn't prevent
+  // returning the successful vehicle sync count.
   if (teslaVehicles.length > 0) {
-    await prisma.settings.upsert({
-      where: { userId },
-      create: { userId, virtualKeyPaired },
-      update: { virtualKeyPaired },
-    });
+    try {
+      await prisma.settings.upsert({
+        where: { userId },
+        create: { userId, virtualKeyPaired },
+        update: { virtualKeyPaired },
+      });
+    } catch (err) {
+      console.error('[sync] Failed to update settings for user', userId, err);
+    }
   }
+
+  const durationMs = Date.now() - startTime;
+  console.log(
+    `[sync] Completed for user ${userId}: ${syncedCount}/${teslaVehicles.length} vehicles synced in ${durationMs}ms`,
+  );
 
   return syncedCount;
 }


### PR DESCRIPTION
## Summary
- **Isolate settings upsert** in its own try/catch — previously it was outside the per-vehicle error handling, so a Prisma client mismatch (e.g. after adding `keyPairingDeferredAt`/`keyPairingReminderCount` columns) would throw unhandled, get silently swallowed by `getVehicles()`, and prevent all vehicle data from being saved
- **Replace `console.warn` → `console.error`** with `[sync]` prefix and context (user ID, vehicle ID, which step failed) so errors surface in Vercel serverless logs
- **Log sync errors in `getVehicles()`** — the catch block was completely silent, hiding the root cause
- **Add sync duration logging** — logs vehicle count and timing on completion for monitoring

Closes #92

## Test plan
- [x] Existing sync tests updated (`console.warn` spy → `console.error`)
- [x] New test: `returns synced count even when settings upsert fails` — verifies isolation fix
- [x] New test: `serves cached data when sync fails and logs the error` — verifies getVehicles logging
- [x] All 289 unit tests pass
- [x] All 25 E2E tests pass
- [x] TypeScript compiles cleanly
- [x] Production build succeeds
- [ ] Deploy to Vercel and verify sync errors now appear in logs
- [ ] Confirm `lastUpdated` advances on page load (no longer stuck stale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)