### PR TITLE
Fix vehicle name fallback chain for empty strings and missing data

### DIFF
--- a/__tests__/lib/tesla-mapper.test.ts
+++ b/__tests__/lib/tesla-mapper.test.ts
@@ -175,7 +175,43 @@ describe('mapTeslaVehicleToUpsertData', () => {
     expect(result.speed).toBe(0);
   });
 
-  it('uses fallback name when display_name is null', () => {
+  it('prefers vehicle_state.vehicle_name when present', () => {
+    const item: TeslaVehicleListItem = { ...listItem, display_name: 'List Name' };
+    const data: TeslaVehicleData = {
+      ...vehicleData,
+      display_name: 'Data Name',
+      vehicle_state: { ...vehicleData.vehicle_state!, vehicle_name: 'Custom Name' },
+    };
+
+    const result = mapTeslaVehicleToUpsertData(item, data);
+    expect(result.name).toBe('Custom Name');
+  });
+
+  it('falls back to listItem.display_name when vehicle_name is empty', () => {
+    const item: TeslaVehicleListItem = { ...listItem, display_name: 'List Name' };
+    const data: TeslaVehicleData = {
+      ...vehicleData,
+      display_name: null,
+      vehicle_state: { ...vehicleData.vehicle_state!, vehicle_name: '' },
+    };
+
+    const result = mapTeslaVehicleToUpsertData(item, data);
+    expect(result.name).toBe('List Name');
+  });
+
+  it('falls back to vehicleData.display_name when listItem.display_name is null', () => {
+    const item: TeslaVehicleListItem = { ...listItem, display_name: null };
+    const data: TeslaVehicleData = {
+      ...vehicleData,
+      display_name: 'Data Name',
+      vehicle_state: { ...vehicleData.vehicle_state!, vehicle_name: null },
+    };
+
+    const result = mapTeslaVehicleToUpsertData(item, data);
+    expect(result.name).toBe('Data Name');
+  });
+
+  it('falls back to "My Tesla" when all name sources are null', () => {
     const noNameItem: TeslaVehicleListItem = { ...listItem, display_name: null };
     const noNameData: TeslaVehicleData = {
       ...vehicleData,
@@ -188,6 +224,7 @@ describe('mapTeslaVehicleToUpsertData', () => {
   });
 
   it('handles missing sub-states for asleep vehicles', () => {
+    const asleepItem: TeslaVehicleListItem = { ...listItem, display_name: null };
     const asleepData: TeslaVehicleData = {
       id: 123,
       vehicle_id: 456,
@@ -196,7 +233,7 @@ describe('mapTeslaVehicleToUpsertData', () => {
       state: 'asleep',
     };
 
-    const result = mapTeslaVehicleToUpsertData(listItem, asleepData);
+    const result = mapTeslaVehicleToUpsertData(asleepItem, asleepData);
     expect(result.name).toBe('Sleepy');
     expect(result.status).toBe('offline');
     expect(result.speed).toBe(0);

--- a/src/features/vehicles/api/sync.ts
+++ b/src/features/vehicles/api/sync.ts
@@ -98,13 +98,13 @@ export async function syncVehiclesFromTesla(userId: string): Promise<number> {
       // Only update fields that have real data to avoid overwriting
       // previous values with mapper defaults.
       const updateData: Record<string, unknown> = {
+        name: upsertData.name,
         chargeLevel: upsertData.chargeLevel,
         estimatedRange: upsertData.estimatedRange,
         lastUpdated: new Date(),
       };
 
       if (fullData) {
-        updateData.name = upsertData.name;
         updateData.model = upsertData.model;
         updateData.year = upsertData.year;
         updateData.status = upsertData.status;

--- a/src/lib/tesla-mapper.ts
+++ b/src/lib/tesla-mapper.ts
@@ -105,7 +105,7 @@ export function mapTeslaVehicleToUpsertData(
   return {
     teslaVehicleId: String(listItem.id),
     vin: vehicleData.vin,
-    name: vehicleData.display_name ?? vehicle_state.vehicle_name ?? 'My Tesla',
+    name: vehicle_state.vehicle_name || listItem.display_name || vehicleData.display_name || 'My Tesla',
     model,
     year,
     chargeLevel: charge_state.battery_level ?? 0,


### PR DESCRIPTION
## Summary
- **Fix `??` → `||`** in name mapping — `??` doesn't catch empty strings, so `vehicle_name: ""` passed through instead of falling back
- **Add `listItem.display_name`** to fallback chain — often the most reliable name source from Tesla API
- **Move name out of `fullData` block** in sync — name comes from `display_name`/list endpoint, not `drive_state`, so it should always be updated (including for vehicles in Service mode)

New fallback order: `vehicle_state.vehicle_name` → `listItem.display_name` → `vehicleData.display_name` → `"My Tesla"`

Closes #89

## Test plan
- [x] New test: prefers `vehicle_state.vehicle_name` when present
- [x] New test: falls back to `listItem.display_name` when `vehicle_name` is empty
- [x] New test: falls back to `vehicleData.display_name` when `listItem.display_name` is null
- [x] New test: falls back to "My Tesla" when all sources are null
- [x] All 292 unit tests pass
- [x] All 25 E2E tests pass
- [x] TypeScript compiles cleanly
- [x] Production build succeeds
- [ ] Verify in production: vehicle names update on next sync after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)