### PR TITLE
Add in_service vehicle status for Tesla Service mode

### DIFF
--- a/__tests__/components/ui/StatusBadge.test.tsx
+++ b/__tests__/components/ui/StatusBadge.test.tsx
@@ -23,6 +23,11 @@ describe('StatusBadge', () => {
     expect(screen.getByText('Offline')).toBeInTheDocument();
   });
 
+  it('renders the in_service label', () => {
+    render(<StatusBadge status="in_service" />);
+    expect(screen.getByText('In Service')).toBeInTheDocument();
+  });
+
   it('applies the correct status color to the label', () => {
     const { container } = render(<StatusBadge status="driving" />);
     const labelSpan = container.querySelectorAll('span')[2]; // outer > dot, label

--- a/__tests__/lib/tesla-mapper.test.ts
+++ b/__tests__/lib/tesla-mapper.test.ts
@@ -42,6 +42,14 @@ describe('mapTeslaStateToVehicleStatus', () => {
   it('prioritizes charging over driving', () => {
     expect(mapTeslaStateToVehicleStatus('online', 'Charging', 30)).toBe('charging');
   });
+
+  it('returns in_service for "in_service" state', () => {
+    expect(mapTeslaStateToVehicleStatus('in_service', null, null)).toBe('in_service');
+  });
+
+  it('prioritizes in_service over charging', () => {
+    expect(mapTeslaStateToVehicleStatus('in_service', 'Charging', 0)).toBe('in_service');
+  });
 });
 
 // ─── celsiusToFahrenheit ─────────────────────────────────────────────────────

--- a/__tests__/lib/vehicle-helpers.test.ts
+++ b/__tests__/lib/vehicle-helpers.test.ts
@@ -36,11 +36,12 @@ function makeVehicle(overrides: Partial<Vehicle> = {}): Vehicle {
 }
 
 describe('STATUS_CONFIG', () => {
-  it('has all four status keys', () => {
+  it('has all five status keys', () => {
     expect(STATUS_CONFIG).toHaveProperty('driving');
     expect(STATUS_CONFIG).toHaveProperty('parked');
     expect(STATUS_CONFIG).toHaveProperty('charging');
     expect(STATUS_CONFIG).toHaveProperty('offline');
+    expect(STATUS_CONFIG).toHaveProperty('in_service');
   });
 
   it('each config has color, label, and dotColor', () => {
@@ -71,6 +72,11 @@ describe('getStatusMessage', () => {
   it('returns offline message with last location', () => {
     const v = makeVehicle({ status: 'offline', locationName: 'Garage' });
     expect(getStatusMessage(v)).toBe('Offline — Last seen at Garage');
+  });
+
+  it('returns in_service message with location', () => {
+    const v = makeVehicle({ status: 'in_service', locationName: 'Tesla Service Center' });
+    expect(getStatusMessage(v)).toBe('In Service at Tesla Service Center');
   });
 });
 
@@ -117,5 +123,6 @@ describe('isDriving', () => {
     expect(isDriving('parked')).toBe(false);
     expect(isDriving('charging')).toBe(false);
     expect(isDriving('offline')).toBe(false);
+    expect(isDriving('in_service')).toBe(false);
   });
 });

--- a/prisma/migrations/20260308020000_add_in_service_status/migration.sql
+++ b/prisma/migrations/20260308020000_add_in_service_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "VehicleStatus" ADD VALUE 'in_service';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,6 +87,7 @@ enum VehicleStatus {
   parked
   charging
   offline
+  in_service
 }
 
 model TripStop {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,6 +58,7 @@
   --color-status-parked: #3B82F6;
   --color-status-charging: #30D158;
   --color-status-offline: #6B6B6B;
+  --color-status-in-service: #FF9F0A;
 
   /* Battery Colors */
   --color-battery-high: #30D158;

--- a/src/features/vehicles/api/vehicle-mappers.ts
+++ b/src/features/vehicles/api/vehicle-mappers.ts
@@ -35,6 +35,7 @@ const VEHICLE_STATUS_MAP: Record<string, VehicleStatus> = {
   parked: 'parked',
   charging: 'charging',
   offline: 'offline',
+  in_service: 'in_service',
 };
 
 function toVehicleStatus(prismaStatus: string): VehicleStatus {

--- a/src/lib/tesla-mapper.ts
+++ b/src/lib/tesla-mapper.ts
@@ -36,6 +36,9 @@ export function mapTeslaStateToVehicleStatus(
   if (vehicleState === 'offline' || vehicleState === 'asleep') {
     return 'offline';
   }
+  if (vehicleState === 'in_service') {
+    return 'in_service';
+  }
   if (chargingState === 'Charging') {
     return 'charging';
   }

--- a/src/lib/vehicle-helpers.ts
+++ b/src/lib/vehicle-helpers.ts
@@ -11,6 +11,7 @@ export const STATUS_CONFIG: StatusConfigMap = {
   parked: { color: '#3B82F6', label: 'Parked', dotColor: 'bg-status-parked' },
   charging: { color: '#30D158', label: 'Charging', dotColor: 'bg-status-charging' },
   offline: { color: '#6B6B6B', label: 'Offline', dotColor: 'bg-status-offline' },
+  in_service: { color: '#FF9F0A', label: 'In Service', dotColor: 'bg-status-in-service' },
 };
 
 /**
@@ -27,6 +28,8 @@ export function getStatusMessage(vehicle: Vehicle): string {
       return `Charging at ${vehicle.locationName} — ${vehicle.chargeLevel}%`;
     case 'offline':
       return `Offline — Last seen at ${vehicle.locationName}`;
+    case 'in_service':
+      return `In Service at ${vehicle.locationName}`;
   }
 }
 

--- a/src/types/vehicle.ts
+++ b/src/types/vehicle.ts
@@ -1,5 +1,5 @@
 /** Vehicle statuses that map to status colors in the design system. */
-export type VehicleStatus = 'driving' | 'parked' | 'charging' | 'offline';
+export type VehicleStatus = 'driving' | 'parked' | 'charging' | 'offline' | 'in_service';
 
 /** A stop along a vehicle's active trip route. */
 export interface TripStop {


### PR DESCRIPTION
## Summary

Closes #96

- Adds `in_service` status across the full stack for vehicles currently at a Tesla Service Center
- Amber color (`#FF9F0A`) distinguishes it from other statuses
- `in_service` takes precedence over charging/speed in the Tesla API mapper (after offline/asleep)
- Uses non-driving bottom sheet layout (same as parked/charging/offline)
- `isDriving('in_service')` returns `false`

### Files changed
- `prisma/schema.prisma` — Added `in_service` to `VehicleStatus` enum
- `prisma/migrations/20260308020000_add_in_service_status/` — Migration to add enum value
- `src/types/vehicle.ts` — Added `'in_service'` to type union
- `src/lib/tesla-mapper.ts` — Added `'in_service'` case (prioritized over charging/speed)
- `src/features/vehicles/api/vehicle-mappers.ts` — Added to status map
- `src/lib/vehicle-helpers.ts` — Added status config + status message
- `src/app/globals.css` — Added `--color-status-in-service: #FF9F0A` theme token
- Tests: `tesla-mapper`, `vehicle-helpers`, `StatusBadge`

## Test plan

- [x] TypeScript compiles with no errors
- [x] All 310 Vitest unit tests pass (including new in_service tests)
- [x] All 25 Playwright E2E tests pass
- [x] Production build succeeds
- [ ] Verify StatusBadge renders amber "In Service" label
- [ ] Verify vehicle with `in_service` status uses parked layout (not driving)
- [ ] Run migration against prod DB (`prisma migrate resolve --applied`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)