### PR TITLE
Add three-state bottom sheet with freeform drag

### DIFF
--- a/__tests__/features/vehicles/hooks/use-bottom-sheet.test.ts
+++ b/__tests__/features/vehicles/hooks/use-bottom-sheet.test.ts
@@ -23,6 +23,12 @@ describe('useBottomSheet', () => {
     expect(result.current.sheetState).toBe('half');
   });
 
+  it('can be initialized with full state', () => {
+    const { result } = renderHook(() => useBottomSheet('full'));
+
+    expect(result.current.sheetState).toBe('full');
+  });
+
   it('returns touch event handlers', () => {
     const { result } = renderHook(() => useBottomSheet());
 
@@ -44,19 +50,58 @@ describe('useBottomSheet', () => {
     expect(result.current.onTouchMove).toBe(firstMove);
   });
 
-  it('toggles from peek to half on toggle()', () => {
+  it('toggles peek → half → full → peek', () => {
     const { result } = renderHook(() => useBottomSheet('peek'));
     expect(result.current.sheetState).toBe('peek');
 
     act(() => { result.current.toggle(); });
     expect(result.current.sheetState).toBe('half');
-  });
 
-  it('toggles from half back to peek on toggle()', () => {
-    const { result } = renderHook(() => useBottomSheet('half'));
+    act(() => { result.current.toggle(); });
+    expect(result.current.sheetState).toBe('full');
 
     act(() => { result.current.toggle(); });
     expect(result.current.sheetState).toBe('peek');
     expect(result.current.currentHeight).toBe(SHEET_PEEK_HEIGHT);
+  });
+
+  it('clamps drag height between floor and full height', () => {
+    const { result } = renderHook(() => useBottomSheet('peek'));
+
+    // Simulate drag start
+    const touchStart = { touches: [{ clientY: 600 }] } as unknown as React.TouchEvent;
+    act(() => { result.current.onTouchStart(touchStart); });
+    expect(result.current.isDragging).toBe(true);
+
+    // Drag far up — should clamp at full height, not exceed it
+    const touchMove = { touches: [{ clientY: 0 }] } as unknown as React.TouchEvent;
+    act(() => { result.current.onTouchMove(touchMove); });
+
+    const fullHeight = Math.round(window.innerHeight * 0.9);
+    expect(result.current.currentHeight).toBeLessThanOrEqual(fullHeight);
+
+    // Drag far down — should clamp at floor (120)
+    const touchMoveDown = { touches: [{ clientY: 1200 }] } as unknown as React.TouchEvent;
+    act(() => { result.current.onTouchMove(touchMoveDown); });
+    expect(result.current.currentHeight).toBe(120);
+  });
+
+  it('snaps to nearest state on release', () => {
+    const { result } = renderHook(() => useBottomSheet('peek'));
+
+    // Simulate drag to just past the peek/half midpoint
+    const touchStart = { touches: [{ clientY: 600 }] } as unknown as React.TouchEvent;
+    act(() => { result.current.onTouchStart(touchStart); });
+
+    // Drag up by enough to pass peek/half midpoint
+    const halfHeight = Math.round(window.innerHeight * 0.5);
+    const midpoint = (SHEET_PEEK_HEIGHT + halfHeight) / 2;
+    const dragDistance = midpoint - SHEET_PEEK_HEIGHT + 20; // past midpoint
+    const touchMove = { touches: [{ clientY: 600 - dragDistance }] } as unknown as React.TouchEvent;
+    act(() => { result.current.onTouchMove(touchMove); });
+
+    act(() => { result.current.onTouchEnd(); });
+    expect(result.current.sheetState).toBe('half');
+    expect(result.current.isDragging).toBe(false);
   });
 });

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -218,12 +218,13 @@ Fixed bottom tab navigation with 4 tabs.
 
 ### Bottom Sheet (Home / Live Map)
 
-Overlay panel with two snap states, using touch-drag with snap logic. The sheet computes a midpoint between peek and half heights; on touch end, if the dragged height exceeds the midpoint, it snaps to half, otherwise to peek.
+Overlay panel with three snap states, using touch-drag with snap-to-nearest logic. During drag, the sheet tracks the finger exactly (no transition). On release, it snaps to whichever snap point is closest to the current height.
 
 | State | Height | Description |
 |---|---|---|
 | Peek | 260px | Compact summary, always visible |
 | Half | 50vh (`window.innerHeight * 0.5`) | Extended details, scrollable |
+| Full | 90vh (`window.innerHeight * 0.9`) | Maximum height, leaves room for status bar |
 
 Content varies depending on whether the vehicle is **driving** or **non-driving** (parked/charging/offline):
 

--- a/src/components/layout/BottomSheet.tsx
+++ b/src/components/layout/BottomSheet.tsx
@@ -70,12 +70,13 @@ export function BottomSheet({
 
 /**
  * Returns true when the half-state content should be visible.
- * True during half state OR when dragging past peek + 30px threshold.
+ * True during half/full state OR when dragging past peek + 30px threshold.
  */
 export function shouldShowHalfContent(
   sheetState: SheetState,
   isDragging: boolean,
   currentHeight: number,
 ): boolean {
-  return sheetState === 'half' || (isDragging && currentHeight > SHEET_PEEK_HEIGHT + 30);
+  return sheetState === 'half' || sheetState === 'full'
+    || (isDragging && currentHeight > SHEET_PEEK_HEIGHT + 30);
 }

--- a/src/features/vehicles/hooks/use-bottom-sheet.ts
+++ b/src/features/vehicles/hooks/use-bottom-sheet.ts
@@ -3,11 +3,11 @@
 import { useState, useRef, useCallback, useMemo } from 'react';
 
 import type { SheetState } from '../types';
-import { SHEET_PEEK_HEIGHT, SHEET_HALF_FRACTION } from '@/lib/constants';
+import { SHEET_PEEK_HEIGHT, SHEET_HALF_FRACTION, SHEET_FULL_FRACTION } from '@/lib/constants';
 
 /** Return type of the useBottomSheet hook. */
 export interface UseBottomSheetReturn {
-  /** Current sheet state (peek or half). */
+  /** Current sheet state (peek, half, or full). */
   sheetState: SheetState;
   /** Whether the user is currently dragging. */
   isDragging: boolean;
@@ -19,7 +19,7 @@ export interface UseBottomSheetReturn {
   onTouchMove: (e: React.TouchEvent) => void;
   /** Touch end handler for the sheet. */
   onTouchEnd: () => void;
-  /** Toggle between peek and half states (for click/keyboard). */
+  /** Cycle through sheet states (for click/keyboard). */
   toggle: () => void;
 }
 
@@ -30,8 +30,31 @@ export interface UseBottomSheetOptions {
 }
 
 /**
+ * Find the nearest snap point to a given height.
+ * Returns the SheetState whose height is closest to the target.
+ */
+function snapToNearest(target: number, heights: Record<SheetState, number>): SheetState {
+  let closest: SheetState = 'peek';
+  let minDist = Math.abs(target - heights.peek);
+
+  const states: SheetState[] = ['half', 'full'];
+  for (const state of states) {
+    const dist = Math.abs(target - heights[state]);
+    if (dist < minDist) {
+      minDist = dist;
+      closest = state;
+    }
+  }
+  return closest;
+}
+
+/**
  * Hook for bottom sheet touch-drag with snap-to-nearest logic.
- * Two states: peek (260px default) and half (50vh). Snap to closest on release.
+ * Three states: peek (260px), half (50vh), full (90vh).
+ *
+ * During drag, height tracks the finger exactly via a ref-based offset
+ * to avoid per-pixel React state updates. Only `currentHeight` re-renders
+ * via a single `sheetOffset` state that updates on each touchmove.
  */
 export function useBottomSheet(
   initialState: SheetState = 'peek',
@@ -50,10 +73,15 @@ export function useBottomSheet(
     ? Math.round(window.innerHeight * SHEET_HALF_FRACTION)
     : 400;
 
+  const fullHeight = typeof window !== 'undefined'
+    ? Math.round(window.innerHeight * SHEET_FULL_FRACTION)
+    : 720;
+
   const heights = useMemo<Record<SheetState, number>>(() => ({
     peek: peekHeight,
     half: halfHeight,
-  }), [peekHeight, halfHeight]);
+    full: fullHeight,
+  }), [peekHeight, halfHeight, fullHeight]);
 
   const onTouchStart = useCallback((e: React.TouchEvent) => {
     dragStartY.current = e.touches[0].clientY;
@@ -72,18 +100,21 @@ export function useBottomSheet(
     setIsDragging(false);
 
     const newHeight = dragStartHeight.current + sheetOffset;
-    const midpoint = (heights.peek + heights.half) / 2;
-
-    setSheetState(newHeight > midpoint ? 'half' : 'peek');
+    setSheetState(snapToNearest(newHeight, heights));
     setSheetOffset(0);
   }, [isDragging, sheetOffset, heights]);
 
   const toggle = useCallback(() => {
-    setSheetState((prev) => (prev === 'peek' ? 'half' : 'peek'));
+    setSheetState((prev) => {
+      if (prev === 'peek') return 'half';
+      if (prev === 'half') return 'full';
+      return 'peek';
+    });
   }, []);
 
+  // Clamp drag height between a min floor and full height
   const currentHeight = isDragging
-    ? Math.max(120, Math.min(heights.half, dragStartHeight.current + sheetOffset))
+    ? Math.max(120, Math.min(heights.full, dragStartHeight.current + sheetOffset))
     : heights[sheetState];
 
   return {

--- a/src/features/vehicles/types.ts
+++ b/src/features/vehicles/types.ts
@@ -7,7 +7,7 @@ import type { Vehicle } from '@/types/vehicle';
 import type { Drive } from '@/types/drive';
 
 /** Bottom sheet snap states. */
-export type SheetState = 'peek' | 'half';
+export type SheetState = 'peek' | 'half' | 'full';
 
 /** Vehicle data combined with its latest drive for the home screen. */
 export interface VehicleWithTrip {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,6 +9,9 @@ export const SHEET_PEEK_HEIGHT = 260;
 /** Bottom sheet half-state height as a fraction of viewport height. */
 export const SHEET_HALF_FRACTION = 0.5;
 
+/** Bottom sheet full-state height as a fraction of viewport height (leaves room for status bar). */
+export const SHEET_FULL_FRACTION = 0.9;
+
 /** Shared viewer bottom sheet peek height in pixels (no BottomNav overlap). */
 export const SHARED_SHEET_PEEK_HEIGHT = 200;
 


### PR DESCRIPTION
## Summary

Closes #76

- Upgrades the bottom sheet from 2-state (peek/half) to **3-state** (peek/half/full) with snap-to-nearest logic
- **Peek** (260px): compact vehicle summary
- **Half** (50vh): extended details, scrollable
- **Full** (90vh): maximum height, leaves room for status bar
- Freeform drag tracks the finger exactly — no transition during active drag for fluid feel
- On release, snaps to whichever point is closest (short, fast animations)
- Toggle (drag handle click) cycles peek → half → full → peek
- Design system doc updated to reflect the new spec

### Files changed
- `src/features/vehicles/types.ts` — Added `'full'` to `SheetState` union
- `src/lib/constants.ts` — Added `SHEET_FULL_FRACTION` (0.9)
- `src/features/vehicles/hooks/use-bottom-sheet.ts` — 3-state snap logic, `snapToNearest` helper
- `src/components/layout/BottomSheet.tsx` — `shouldShowHalfContent` handles full state
- `docs/design/design-system.md` — Updated bottom sheet spec
- `__tests__/features/vehicles/hooks/use-bottom-sheet.test.ts` — 9 tests (2 new)

## Test plan

- [x] TypeScript compiles with no errors
- [x] All 313 Vitest unit tests pass
- [x] All 25 Playwright E2E tests pass
- [x] Production build succeeds
- [ ] Test on mobile: drag sheet smoothly between peek, half, and full
- [ ] Verify snap-to-nearest feels fast and natural on release
- [ ] Verify drag handle click cycles through all three states
- [ ] Verify SharedViewerScreen also gets the 3-state behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)