### PR TITLE
Fix in_service detection: check boolean field, not just state string

### DIFF
--- a/__tests__/lib/tesla-mapper.test.ts
+++ b/__tests__/lib/tesla-mapper.test.ts
@@ -50,6 +50,18 @@ describe('mapTeslaStateToVehicleStatus', () => {
   it('prioritizes in_service over charging', () => {
     expect(mapTeslaStateToVehicleStatus('in_service', 'Charging', 0)).toBe('in_service');
   });
+
+  it('returns in_service when in_service boolean is true', () => {
+    expect(mapTeslaStateToVehicleStatus('online', null, 0, true)).toBe('in_service');
+  });
+
+  it('returns in_service via boolean even when charging', () => {
+    expect(mapTeslaStateToVehicleStatus('online', 'Charging', 0, true)).toBe('in_service');
+  });
+
+  it('ignores in_service boolean when vehicle is offline', () => {
+    expect(mapTeslaStateToVehicleStatus('offline', null, null, true)).toBe('offline');
+  });
 });
 
 // ─── celsiusToFahrenheit ─────────────────────────────────────────────────────
@@ -127,6 +139,7 @@ describe('mapTeslaVehicleToUpsertData', () => {
     vin: '5YJYE1EA1SF000001',
     display_name: 'My Tesla',
     state: 'online',
+    in_service: false,
     drive_state: {
       latitude: 30.325,
       longitude: -97.738,
@@ -239,6 +252,7 @@ describe('mapTeslaVehicleToUpsertData', () => {
       vin: '5YJ3E1EA1PF000001',
       display_name: 'Sleepy',
       state: 'asleep',
+      in_service: false,
     };
 
     const result = mapTeslaVehicleToUpsertData(asleepItem, asleepData);

--- a/src/lib/tesla-client.ts
+++ b/src/lib/tesla-client.ts
@@ -62,6 +62,7 @@ export interface TeslaVehicleData {
   vin: string;
   display_name: string | null;
   state: string;
+  in_service: boolean;
   drive_state?: TeslaDriveState;
   charge_state?: TeslaChargeState;
   vehicle_state?: TeslaVehicleState;

--- a/src/lib/tesla-mapper.ts
+++ b/src/lib/tesla-mapper.ts
@@ -32,11 +32,12 @@ export function mapTeslaStateToVehicleStatus(
   vehicleState: string,
   chargingState: string | null,
   speed: number | null,
+  inService?: boolean,
 ): VehicleStatus {
   if (vehicleState === 'offline' || vehicleState === 'asleep') {
     return 'offline';
   }
-  if (vehicleState === 'in_service') {
+  if (inService || vehicleState === 'in_service') {
     return 'in_service';
   }
   if (chargingState === 'Charging') {
@@ -117,6 +118,7 @@ export function mapTeslaVehicleToUpsertData(
       vehicleData.state,
       charge_state.charging_state ?? null,
       drive_state.speed ?? null,
+      vehicleData.in_service,
     ),
     speed: drive_state.speed ?? 0,
     heading: drive_state.heading ?? 0,


### PR DESCRIPTION
## Summary

Fixes #109

PR #108 was merged before this fix was pushed. The original implementation only checked `vehicleData.state === 'in_service'`, but Tesla's Fleet API reports service mode via a **separate boolean field** `in_service: true` — the `state` field often stays `'online'` even when the vehicle is at a service center.

- Added `in_service: boolean` to `TeslaVehicleData` interface
- `mapTeslaStateToVehicleStatus` now accepts an optional `inService` boolean
- Checks `inService || vehicleState === 'in_service'` (both paths covered)
- `mapTeslaVehicleToUpsertData` passes `vehicleData.in_service` through
- 3 new tests for the boolean detection path

## Test plan

- [x] TypeScript compiles with no errors
- [x] All 318 Vitest unit tests pass
- [ ] Deploy and verify 2026 Model Y in service mode shows "In Service" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)