### PR TITLE
Add diagnostic logging for Tesla API virtual key data

### DIFF
--- a/src/features/vehicles/api/sync.ts
+++ b/src/features/vehicles/api/sync.ts
@@ -94,13 +94,14 @@ export async function syncVehiclesFromTesla(userId: string): Promise<number> {
         }
       }
 
+      // TODO(#127): remove diagnostic logging once virtual key issue is resolved
       const presentCategories = [
         vehicleData.charge_state ? 'charge_state' : null,
         vehicleData.climate_state ? 'climate_state' : null,
         vehicleData.drive_state ? 'drive_state' : null,
         vehicleData.vehicle_state ? 'vehicle_state' : null,
       ].filter(Boolean);
-      console.log(
+      console.info(
         `[sync] Vehicle ${listItem.id} (${listItem.vin}): state=${vehicleData.state}, in_service=${vehicleData.in_service}, categories=[${presentCategories.join(', ')}]`,
       );
 


### PR DESCRIPTION
## Summary

- Track virtual key pairing per vehicle (on `Vehicle` model) instead of globally on `Settings`
- Add `virtualKeyPaired` field to Vehicle, with migration
- Update key pairing banner to dismiss per vehicle
- Add diagnostic logging to sync to capture which data categories Tesla returns per vehicle (`charge_state`, `climate_state`, `drive_state`, `vehicle_state`)

Fixes #91
Relates to #127

## Context

After pairing the virtual key successfully (confirmed on car under Locks), the Tesla Fleet API still only returns `charge_state`. The diagnostic logging will help identify whether this is a scope issue, token issue, or Tesla-side propagation delay.

## Test plan

- [x] TypeScript compiles with no errors
- [x] All 352 unit tests pass
- [x] Verify diagnostic logs appear in Vercel after deploy
- [ ] Check Vercel logs after next sync to see returned categories
- [ ] Based on findings, follow up with fix in #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)