### PR TITLE
Add vehicle_cmds to Tesla OAuth scopes

### DIFF
--- a/__tests__/lib/tesla.test.ts
+++ b/__tests__/lib/tesla.test.ts
@@ -51,6 +51,7 @@ describe('Tesla constants', () => {
     expect(TESLA_SCOPES).toContain('openid');
     expect(TESLA_SCOPES).toContain('offline_access');
     expect(TESLA_SCOPES).toContain('vehicle_device_data');
+    expect(TESLA_SCOPES).toContain('vehicle_cmds');
     expect(TESLA_SCOPES).toContain('vehicle_location');
   });
 });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -344,7 +344,7 @@ async function main() {
       refresh_token: 'dev-tesla-refresh-token',
       expires_at: Math.floor(Date.now() / 1000) + 86400,
       token_type: 'Bearer',
-      scope: 'openid offline_access user_data vehicle_device_data vehicle_location',
+      scope: 'openid offline_access user_data vehicle_device_data vehicle_cmds vehicle_location',
     },
   });
   console.log('Upserted Tesla account');

--- a/src/lib/tesla.ts
+++ b/src/lib/tesla.ts
@@ -15,7 +15,7 @@ export const TESLA_USERINFO_URL =
 export const TESLA_AUDIENCE = 'https://fleet-api.prd.na.vn.cloud.tesla.com';
 export const TESLA_ISSUER = 'https://auth.tesla.com/oauth2/v3/nts';
 export const TESLA_SCOPES =
-  'openid email offline_access user_data vehicle_device_data vehicle_location';
+  'openid email offline_access user_data vehicle_device_data vehicle_cmds vehicle_location';
 
 // ─── Token refresh ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `vehicle_cmds` to the Tesla OAuth scopes requested during authorization
- Tesla may require this scope for the Fleet API to recognize virtual key pairing and return full vehicle data (`drive_state`, `climate_state`, `vehicle_state`) instead of only `charge_state`

## Context

After pairing the virtual key (confirmed on car), the Fleet API still only returns `charge_state` (confirmed via diagnostic logging in #128). Adding this scope and re-linking the Tesla account should grant full data access.

Fixes #127

## Test plan

- [x] TypeScript compiles with no errors
- [x] All 352 unit tests pass (including updated scope assertion)
- [ ] After deploy: unlink Tesla in Settings, re-link, pair virtual key, verify full data categories in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)