### PR TITLE
Combine Tesla diagnostic logs into single line

### DIFF
--- a/__tests__/features/vehicles/api/actions-sync.test.ts
+++ b/__tests__/features/vehicles/api/actions-sync.test.ts
@@ -51,6 +51,7 @@ vi.mock('@/lib/tesla-mapper', () => ({
 }));
 
 const mockVehicleUpsert = vi.fn();
+const mockVehicleFindUnique = vi.fn();
 const mockVehicleFindFirst = vi.fn();
 const mockVehicleFindMany = vi.fn();
 const mockSettingsUpsert = vi.fn();
@@ -63,6 +64,7 @@ vi.mock('@/lib/prisma', () => ({
     },
     vehicle: {
       upsert: (...args: unknown[]) => mockVehicleUpsert(...args),
+      findUnique: (...args: unknown[]) => mockVehicleFindUnique(...args),
       findFirst: (...args: unknown[]) => mockVehicleFindFirst(...args),
       findMany: (...args: unknown[]) => mockVehicleFindMany(...args),
     },
@@ -222,6 +224,34 @@ describe('syncVehiclesFromTesla', () => {
       expect.objectContaining({
         create: expect.objectContaining({ virtualKeyPaired: false }),
         update: expect.objectContaining({ virtualKeyPaired: false }),
+      }),
+    );
+  });
+
+  it('preserves existing virtualKeyPaired when fleet_status fails', async () => {
+    mockGetTeslaAccessToken.mockResolvedValue('test-token');
+    mockListVehicles.mockResolvedValue([
+      { id: 123, vehicle_id: 456, vin: 'VIN1', display_name: 'Car 1', state: 'online' },
+    ]);
+    mockGetVehicleData.mockResolvedValue({
+      id: 123,
+      vin: 'VIN1',
+      state: 'online',
+      charge_state: { battery_level: 80 },
+    });
+    // fleet_status fails → returns null
+    mockGetFleetStatus.mockResolvedValue(null);
+    // Existing DB record has virtualKeyPaired: true
+    mockVehicleFindUnique.mockResolvedValue({ virtualKeyPaired: true });
+    mockVehicleUpsert.mockResolvedValue({});
+    mockSettingsUpsert.mockResolvedValue({});
+
+    const count = await syncVehiclesFromTesla('user-1');
+
+    expect(count).toBe(1);
+    expect(mockVehicleUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ virtualKeyPaired: true }),
       }),
     );
   });

--- a/src/features/vehicles/api/sync.ts
+++ b/src/features/vehicles/api/sync.ts
@@ -97,7 +97,8 @@ export async function syncVehiclesFromTesla(userId: string): Promise<number> {
 
       // Use fleet_status to determine virtual key pairing (more reliable
       // than checking if drive_state is present in the response).
-      const keyPaired = await getFleetStatus(accessToken, listItem.id);
+      // Returns null on error — preserve existing DB value in that case.
+      const keyPairedResult = await getFleetStatus(accessToken, listItem.id);
 
       // TODO(#127): remove diagnostic logging once virtual key issue is resolved
       const presentCategories = [
@@ -107,15 +108,28 @@ export async function syncVehiclesFromTesla(userId: string): Promise<number> {
         vehicleData.vehicle_state ? 'vehicle_state' : null,
       ].filter(Boolean);
       console.info(
-        `[sync] Vehicle ${listItem.id} (${listItem.vin}): state=${vehicleData.state}, in_service=${vehicleData.in_service}, key_paired=${keyPaired}, categories=[${presentCategories.join(', ')}]`,
+        `[sync] Vehicle ${listItem.id} (${listItem.vin}): state=${vehicleData.state}, in_service=${vehicleData.in_service}, key_paired=${keyPairedResult}, categories=[${presentCategories.join(', ')}]`,
       );
 
       const fullData = hasFullData(vehicleData);
       totalCount++;
-      if (keyPaired) pairedCount++;
 
       const upsertData = mapTeslaVehicleToUpsertData(listItem, vehicleData);
       const teslaVehicleId = upsertData.teslaVehicleId;
+
+      // When fleet_status fails (null), look up the existing DB value
+      // so we don't flip a paired vehicle back to unpaired on a transient error.
+      let keyPaired: boolean;
+      if (keyPairedResult !== null) {
+        keyPaired = keyPairedResult;
+      } else {
+        const existing = await prisma.vehicle.findUnique({
+          where: { teslaVehicleId },
+          select: { virtualKeyPaired: true },
+        });
+        keyPaired = existing?.virtualKeyPaired ?? false;
+      }
+      if (keyPaired) pairedCount++;
 
       // Skip lat/lng update when Tesla returns 0,0 (vehicle asleep/offline)
       // to preserve the last known position in the database.

--- a/src/lib/tesla-client.ts
+++ b/src/lib/tesla-client.ts
@@ -176,7 +176,7 @@ export async function getVehicleData(
 export async function getFleetStatus(
   accessToken: string,
   vehicleId: number,
-): Promise<boolean> {
+): Promise<boolean | null> {
   try {
     const res = await fetchWithRetry(
       `${BASE_URL}/api/1/vehicles/${vehicleId}/fleet_status`,
@@ -188,7 +188,7 @@ export async function getFleetStatus(
     return data.response?.key_paired === true;
   } catch (err) {
     console.error(`[tesla-client] fleet_status for ${vehicleId} failed:`, err);
-    return false;
+    return null; // Unknown — caller should preserve existing DB value
   }
 }
 


### PR DESCRIPTION
## Summary

- Combines diagnostic logs into a single line (Vercel was dropping the second `console.info`)
- Adds `fleet_status` API call to check if Tesla's servers recognize the virtual key pairing
- Uses `fleet_status.key_paired` instead of `hasFullData()` (drive_state presence) to determine `virtualKeyPaired` — this correctly drives the "Pair Now" banner even when Tesla withholds drive_state
- Logs `granular_access` and `access_type` for debugging

Relates to #127

## Test plan

- [x] TypeScript compiles with no errors
- [x] All 352 unit tests pass (updated sync tests to mock `getFleetStatus`)
- [ ] After deploy: reload app, verify "Pair Now" banner reflects `fleet_status.key_paired`
- [ ] Check Vercel logs for `fleet_status` response and `granular_access` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)