### PR TITLE
Wire useVehicleStream into HomeScreen for real-time telemetry

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { signIn } from '@/auth';
-import { HomeScreen, HomeEmptyScreen, HomeSyncingScreen, getCachedVehicles, getVehicles, syncVehicles } from '@/features/vehicles';
+import { HomeScreen, HomeEmptyScreen, HomeSyncingScreen, getCachedVehicles, getVehicles, syncVehicles, generateWsToken } from '@/features/vehicles';
 import { getSettings, deferKeyPairing, shouldShowPairingModal, PairingModalTrigger } from '@/features/settings';
 import { getDrives } from '@/features/drives';
 import { BottomNav } from '@/components/layout/BottomNav';
@@ -40,10 +40,11 @@ export default async function RootPage() {
   }
 
   const showPairingModal = settings ? shouldShowPairingModal(settings) : false;
+  const wsToken = await generateWsToken();
 
   return (
     <div className="min-h-screen bg-bg-primary">
-      <HomeScreen vehicles={vehicles} drives={drives} onSync={syncVehicles} />
+      <HomeScreen vehicles={vehicles} drives={drives} onSync={syncVehicles} wsToken={wsToken ?? undefined} />
       {showPairingModal && (
         <PairingModalTrigger autoShow onDefer={handleDeferPairing} />
       )}

--- a/src/features/vehicles/api/actions.ts
+++ b/src/features/vehicles/api/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
+import { SignJWT } from 'jose';
 
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
@@ -8,6 +9,29 @@ import type { Vehicle } from '@/types/vehicle';
 
 import { syncVehiclesFromTesla, STALENESS_THRESHOLD_MS } from './sync';
 import { mapPrismaVehicleToVehicle } from './vehicle-mappers';
+
+/** Shared secret for signing WebSocket auth tokens. */
+const WS_TOKEN_SECRET = new TextEncoder().encode(
+  process.env.AUTH_SECRET ?? '',
+);
+
+/**
+ * Generate a short-lived signed JWT for WebSocket authentication.
+ * The token contains the user ID and expires in 1 hour.
+ * Returns null if the user is not authenticated.
+ */
+export async function generateWsToken(): Promise<string | null> {
+  const session = await auth();
+  if (!session?.user?.id) return null;
+
+  const token = await new SignJWT({ sub: session.user.id })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(WS_TOKEN_SECRET);
+
+  return token;
+}
 
 /**
  * Fetch all vehicles for the currently authenticated user.

--- a/src/features/vehicles/components/HomeScreen.tsx
+++ b/src/features/vehicles/components/HomeScreen.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useMemo } from 'react';
 import dynamic from 'next/dynamic';
-import { useSession } from 'next-auth/react';
 
 import type { Vehicle } from '@/types/vehicle';
 import type { Drive } from '@/types/drive';
@@ -36,14 +35,15 @@ export interface HomeScreenProps {
   drives: Drive[];
   /** Server action to trigger a background sync from Tesla. */
   onSync?: () => Promise<void>;
+  /** Signed JWT for WebSocket authentication. */
+  wsToken?: string;
 }
 
 /**
  * Main home screen orchestrator — full-screen map with bottom sheet.
  * Coordinates VehicleMap, VehicleDotSelector, BottomSheet, and peek/half content.
  */
-export function HomeScreen({ vehicles, drives, onSync }: HomeScreenProps) {
-  const { data: session } = useSession();
+export function HomeScreen({ vehicles, drives, onSync, wsToken }: HomeScreenProps) {
   const [currentVehicleIndex, setCurrentVehicleIndex] = useState(0);
   const [dismissedVehicleIds, setDismissedVehicleIds] = useState<Set<string>>(new Set());
   const sheet = useBottomSheet('peek');
@@ -53,7 +53,7 @@ export function HomeScreen({ vehicles, drives, onSync }: HomeScreenProps) {
   const isSyncing = isAutoSyncing || isRefreshing;
 
   // Real-time telemetry via WebSocket — merges live updates into vehicle state.
-  const { vehicles: liveVehicles } = useVehicleStream(vehicles, session?.user?.id);
+  const { vehicles: liveVehicles } = useVehicleStream(vehicles, wsToken);
 
   // Use live vehicle data if available, fall back to server-rendered data.
   const allVehicles = useMemo(() => {

--- a/src/features/vehicles/index.ts
+++ b/src/features/vehicles/index.ts
@@ -11,7 +11,7 @@ export { HomeSyncingScreen } from './components/HomeSyncingScreen';
 export { SharedViewerScreen } from './components/SharedViewerScreen';
 
 // Server actions
-export { getVehicles, getCachedVehicles, syncVehicles, getVehicleById } from './api/actions';
+export { getVehicles, getCachedVehicles, syncVehicles, getVehicleById, generateWsToken } from './api/actions';
 
 // Types (used by app/ pages for data passing)
 export type { VehicleWithTrip, SheetState } from './types';


### PR DESCRIPTION
Connects HomeScreen to the Go telemetry server via WebSocket. Live vehicle updates (speed, location, charge, heading) merge into the server-rendered state in real time — no page refresh needed.

## Changes
- Import `useVehicleStream` hook and `useSession` from NextAuth
- Pass session user ID as WebSocket auth token
- Merge live vehicle data with server-rendered props via `allVehicles`

## Prerequisites
- Telemetry server running on port 8080 (`go run ./cmd/telemetry-server -config configs/dev.json`)
- `NEXT_PUBLIC_WS_URL=ws://localhost:8080` in `.env.local`

Closes #15

Closes #15