### PR TITLE
#177 Tesla-like follow/free map interaction mode

### DIFF
--- a/src/components/map/VehicleMap.tsx
+++ b/src/components/map/VehicleMap.tsx
@@ -8,7 +8,7 @@ import { MAPBOX_DEFAULT_CENTER, MAPBOX_DEFAULT_ZOOM, MAPBOX_GOLD } from '@/lib/m
 import { useMapInstance } from './hooks/use-map-instance';
 import { useVehicleMarker } from './hooks/use-vehicle-marker';
 import { useRouteLayer } from './hooks/use-route-layer';
-import { useMapRecenter } from './hooks/use-map-recenter';
+import { useMapFollow } from './hooks/use-map-follow';
 
 /** Props for the VehicleMap component. */
 export interface VehicleMapProps {
@@ -69,7 +69,7 @@ export function VehicleMap({
     map, mapLoaded, showRoute, routeCoordinates, markerPos,
   );
 
-  const { isOffCenter, recenter } = useMapRecenter(map, mapLoaded, validCenter);
+  const { isOffCenter, recenter } = useMapFollow(map, mapLoaded, markerPos);
 
   const showFitButton = showRoute && routeCoordinates && routeCoordinates.length >= 2;
 

--- a/src/components/map/hooks/use-map-follow.ts
+++ b/src/components/map/hooks/use-map-follow.ts
@@ -1,0 +1,126 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type mapboxgl from 'mapbox-gl';
+
+import type { LngLat } from '@/types/drive';
+
+/** Street-level zoom used when following the vehicle. */
+const FOLLOW_ZOOM = 15;
+
+/** Duration in ms for the flyTo animation when tracking the vehicle. */
+const FLY_TO_DURATION = 800;
+
+/** Duration in ms for the flyTo animation when re-centering. */
+const RECENTER_DURATION = 1000;
+
+/** Return type of the useMapFollow hook. */
+export interface UseMapFollowReturn {
+  /** Whether the map is not following the vehicle (user panned/zoomed away). */
+  isOffCenter: boolean;
+  /** Whether the map is actively tracking the vehicle position. */
+  followMode: boolean;
+  /** Re-enter follow mode and fly to the vehicle position. */
+  recenter: () => void;
+}
+
+/**
+ * Tesla-like map follow/free interaction mode.
+ *
+ * **Follow mode (default):** Map smoothly tracks the vehicle via `flyTo` at
+ * street-level zoom. Centered on the vehicle position.
+ *
+ * **Free mode (user-initiated):** Entered when the user pans, zooms, pinches,
+ * or rotates the map. Auto-tracking is suppressed and the recenter button
+ * becomes visible.
+ *
+ * **Re-center:** Calling `recenter()` returns to follow mode and flies to the
+ * current vehicle position.
+ */
+export function useMapFollow(
+  map: React.RefObject<mapboxgl.Map | null>,
+  mapLoaded: boolean,
+  vehiclePosition: LngLat,
+): UseMapFollowReturn {
+  const [followMode, setFollowMode] = useState(true);
+
+  // Track whether a programmatic flyTo is in progress so we don't
+  // interpret the resulting map events as user gestures.
+  const programmaticMoveRef = useRef(false);
+
+  // ── Listen for user gestures to exit follow mode ──────────────────────
+  useEffect(() => {
+    const m = map.current;
+    if (!m || !mapLoaded) return;
+
+    function onUserGesture() {
+      // Ignore events triggered by our own flyTo calls
+      if (programmaticMoveRef.current) return;
+      setFollowMode(false);
+    }
+
+    m.on('dragstart', onUserGesture);
+    m.on('zoomstart', onUserGesture);
+    m.on('pitchstart', onUserGesture);
+    m.on('rotatestart', onUserGesture);
+
+    return () => {
+      m.off('dragstart', onUserGesture);
+      m.off('zoomstart', onUserGesture);
+      m.off('pitchstart', onUserGesture);
+      m.off('rotatestart', onUserGesture);
+    };
+  }, [map, mapLoaded]);
+
+  // ── Follow mode: flyTo on every vehicle position update ───────────────
+  useEffect(() => {
+    const m = map.current;
+    if (!m || !mapLoaded || !followMode) return;
+
+    // Skip 0,0 coordinates (vehicle asleep/offline)
+    if (vehiclePosition[0] === 0 && vehiclePosition[1] === 0) return;
+
+    programmaticMoveRef.current = true;
+
+    m.flyTo({
+      center: vehiclePosition,
+      zoom: FOLLOW_ZOOM,
+      duration: FLY_TO_DURATION,
+    });
+
+    // Clear the programmatic flag after the animation completes
+    const timer = setTimeout(() => {
+      programmaticMoveRef.current = false;
+    }, FLY_TO_DURATION + 50);
+
+    return () => {
+      clearTimeout(timer);
+      programmaticMoveRef.current = false;
+    };
+  }, [map, mapLoaded, followMode, vehiclePosition[0], vehiclePosition[1]]);
+
+  // ── Recenter: re-enter follow mode ────────────────────────────────────
+  const recenter = useCallback(() => {
+    const m = map.current;
+    if (!m) return;
+
+    programmaticMoveRef.current = true;
+    setFollowMode(true);
+
+    m.flyTo({
+      center: vehiclePosition,
+      zoom: FOLLOW_ZOOM,
+      duration: RECENTER_DURATION,
+    });
+
+    setTimeout(() => {
+      programmaticMoveRef.current = false;
+    }, RECENTER_DURATION + 50);
+  }, [map, vehiclePosition[0], vehiclePosition[1]]);
+
+  return {
+    isOffCenter: !followMode,
+    followMode,
+    recenter,
+  };
+}

--- a/src/components/map/hooks/use-route-layer.ts
+++ b/src/components/map/hooks/use-route-layer.ts
@@ -13,8 +13,11 @@ import {
 import { splitRoute } from '@/lib/route-utils';
 
 /**
- * Manages route rendering on the map — two-tone segments, start/end markers, fitBounds.
- * Returns a fitToRoute callback for external trigger.
+ * Manages route rendering on the map — two-tone segments, start/end markers.
+ *
+ * fitBounds is only called on initial route load (when routeCoordinates
+ * changes), NOT on every vehicle position update. The fitToRoute callback
+ * is exposed for the fit-to-route button.
  */
 export function useRouteLayer(
   map: React.RefObject<mapboxgl.Map | null>,
@@ -25,7 +28,25 @@ export function useRouteLayer(
 ): { fitToRoute: () => void } {
   const startMarkerRef = useRef<mapboxgl.Marker | null>(null);
   const endMarkerRef = useRef<mapboxgl.Marker | null>(null);
+  const initialFitDoneRef = useRef(false);
 
+  // ── Fit bounds on initial route load only ─────────────────────────────
+  useEffect(() => {
+    const m = map.current;
+    if (!m || !mapLoaded || !showRoute || !routeCoordinates || routeCoordinates.length < 2) {
+      initialFitDoneRef.current = false;
+      return;
+    }
+
+    if (!initialFitDoneRef.current) {
+      const bounds = new mapboxgl.LngLatBounds();
+      routeCoordinates.forEach((c) => bounds.extend(c as [number, number]));
+      m.fitBounds(bounds, { padding: MAPBOX_FIT_BOUNDS_PADDING, maxZoom: MAPBOX_FIT_BOUNDS_MAX_ZOOM });
+      initialFitDoneRef.current = true;
+    }
+  }, [map, mapLoaded, showRoute, routeCoordinates]);
+
+  // ── Render route layers and markers ───────────────────────────────────
   useEffect(() => {
     const m = map.current;
     if (!m || !mapLoaded) return;
@@ -81,11 +102,6 @@ export function useRouteLayer(
     const endEl = document.createElement('div');
     endEl.style.cssText = `width:10px;height:10px;border-radius:50%;background:${MAPBOX_GOLD};border:2px solid rgba(255,255,255,0.5);box-shadow:0 0 6px rgba(201,168,76,0.5);`;
     endMarkerRef.current = new mapboxgl.Marker({ element: endEl }).setLngLat(routeCoordinates[routeCoordinates.length - 1]).addTo(m);
-
-    // Fit bounds
-    const bounds = new mapboxgl.LngLatBounds();
-    routeCoordinates.forEach((c) => bounds.extend(c as [number, number]));
-    m.fitBounds(bounds, { padding: MAPBOX_FIT_BOUNDS_PADDING, maxZoom: MAPBOX_FIT_BOUNDS_MAX_ZOOM });
   }, [map, mapLoaded, showRoute, routeCoordinates, vehiclePosition]);
 
   const fitToRoute = useCallback(() => {


### PR DESCRIPTION
Fixes the map snapping back to route overview on every vehicle update.

## Changes
- **New `useMapFollow` hook** — follow/free mode state machine. Follow mode tracks vehicle via flyTo. User gestures enter free mode. Recenter button returns to follow.
- **Split `useRouteLayer`** — fitBounds only fires once per new route (not on every position update). Route rendering still updates with vehiclePosition for segment splitting.
- **Replaces `useMapRecenter`** in VehicleMap

## Behavior
- Default: map smoothly follows vehicle at street-level zoom (15)
- User pinch/zoom/pan: tracking paused, recenter button visible
- Recenter tap: returns to follow mode with smooth animation
- Fit-to-route button: one-shot fitBounds, stays in free mode

Closes #177