### PR TITLE
#180 Add 3D building extrusions to map

### DIFF
--- a/src/components/map/hooks/use-map-instance.ts
+++ b/src/components/map/hooks/use-map-instance.ts
@@ -46,6 +46,24 @@ export function useMapInstance(
     map.current = m;
     m.on('load', () => {
       m.resize();
+
+      // 3D building extrusions — visible when map is tilted (heading-up mode)
+      if (!m.getLayer('3d-buildings')) {
+        m.addLayer({
+          id: '3d-buildings',
+          source: 'composite',
+          'source-layer': 'building',
+          type: 'fill-extrusion',
+          minzoom: 14,
+          paint: {
+            'fill-extrusion-color': '#1a1a2e',
+            'fill-extrusion-height': ['get', 'height'],
+            'fill-extrusion-base': ['get', 'min_height'],
+            'fill-extrusion-opacity': 0.6,
+          },
+        });
+      }
+
       setMapLoaded(true);
     });
 


### PR DESCRIPTION
Adds fill-extrusion layer for 3D buildings visible when the map is tilted (heading-up mode). Creates a Tesla-like immersive view when driving through cities.

- Dark building color (#1a1a2e) matching the dark theme
- 60% opacity — visible but not overwhelming
- Min zoom 14 — only at street level
- Uses built-in `building` source from `dark-v11` style

Closes #180