### PR TITLE
Add iss and aud claims to telemetry server JWTs

### DIFF
--- a/src/features/vehicles/api/actions.ts
+++ b/src/features/vehicles/api/actions.ts
@@ -7,6 +7,8 @@ import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import type { Vehicle } from '@/types/vehicle';
 
+import { JWT_ISSUER, JWT_AUDIENCE } from '@/lib/constants';
+
 import { syncVehiclesFromTesla, STALENESS_THRESHOLD_MS } from './sync';
 import { mapPrismaVehicleToVehicle } from './vehicle-mappers';
 
@@ -26,8 +28,8 @@ export async function generateWsToken(): Promise<string | null> {
 
   const token = await new SignJWT({ sub: session.user.id })
     .setProtectedHeader({ alg: 'HS256' })
-    .setIssuer('myrobotaxi')
-    .setAudience('telemetry')
+    .setIssuer(JWT_ISSUER)
+    .setAudience(JWT_AUDIENCE)
     .setIssuedAt()
     .setExpirationTime('1h')
     .sign(WS_TOKEN_SECRET);

--- a/src/features/vehicles/api/fleet-config.ts
+++ b/src/features/vehicles/api/fleet-config.ts
@@ -1,5 +1,7 @@
 import { SignJWT } from 'jose';
 
+import { JWT_ISSUER, JWT_AUDIENCE } from '@/lib/constants';
+
 /**
  * Push fleet telemetry config for a vehicle via the telemetry server.
  * Called after virtual key pairing is detected during sync.
@@ -22,8 +24,8 @@ export async function pushFleetConfig(userId: string, vin: string): Promise<void
   const secret = new TextEncoder().encode(authSecret);
   const token = await new SignJWT({ sub: userId })
     .setProtectedHeader({ alg: 'HS256' })
-    .setIssuer('myrobotaxi')
-    .setAudience('telemetry')
+    .setIssuer(JWT_ISSUER)
+    .setAudience(JWT_AUDIENCE)
     .setIssuedAt()
     .setExpirationTime('5m')
     .sign(secret);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -36,5 +36,9 @@ export const FALLBACK_POLL_INTERVAL = 10_000;
 /** Routes where the bottom nav is hidden. */
 export const HIDDEN_NAV_ROUTES = ['/signin', '/signup', '/empty', '/shared'];
 
+/** JWT claims for telemetry server authentication. Must match auth.token_issuer / auth.token_audience in the Go server config. */
+export const JWT_ISSUER = 'myrobotaxi';
+export const JWT_AUDIENCE = 'telemetry';
+
 /** Tesla virtual key pairing deep link. */
 export const TESLA_KEY_PAIRING_URL = 'https://tesla.com/_ak/myrobotaxi.app';


### PR DESCRIPTION
## Summary

Closes #182 — The telemetry server validates `iss` and `aud` claims on JWTs. Both `generateWsToken()` and `pushFleetConfig()` were missing these, causing 401 rejections.

- `generateWsToken()` — adds `.setIssuer('myrobotaxi').setAudience('telemetry')` for WebSocket auth
- `pushFleetConfig()` — adds the same claims for fleet config push

Values match `auth.token_issuer` and `auth.token_audience` in the telemetry server config.

## Test plan
- [ ] Fleet config push returns 200 instead of 401
- [ ] WebSocket connection authenticates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)