### PR TITLE
Fix Step 2 hang: add 'use server' to fleet-config.ts

### DIFF
--- a/src/features/vehicles/api/fleet-config.ts
+++ b/src/features/vehicles/api/fleet-config.ts
@@ -1,3 +1,5 @@
+'use server';
+
 import { SignJWT } from 'jose';
 
 import { JWT_ISSUER, JWT_AUDIENCE } from '@/lib/constants';


### PR DESCRIPTION
## Summary

Hotfix for #195 — Step 2 of the onboarding stepper hangs indefinitely.

**Root cause:** `fleet-config.ts` was missing the `'use server'` directive. When imported by the `'use client'` hook, `pushFleetConfig` was bundled into the browser where `process.env.TELEMETRY_API_URL` is `undefined`, causing the function to silently no-op. Step 2 then hung waiting for a config push that never happened.

**Fix:** Add `'use server'` to `fleet-config.ts` so Next.js properly serializes it as a server action callable from the client.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 589/589 pass
- [ ] Manual: open app → stepper should advance past Step 2 within seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)