### PR TITLE
#204 Add navigation coordinate columns to Vehicle table

### DIFF
--- a/prisma/migrations/20260328045929_add_navigation_coordinates/migration.sql
+++ b/prisma/migrations/20260328045929_add_navigation_coordinates/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Vehicle" ADD COLUMN     "destinationLatitude" DOUBLE PRECISION,
+ADD COLUMN     "destinationLongitude" DOUBLE PRECISION,
+ADD COLUMN     "originLatitude" DOUBLE PRECISION,
+ADD COLUMN     "originLongitude" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,9 +70,13 @@ model Vehicle {
   fsdMilesToday    Float         @default(0)
   virtualKeyPaired Boolean       @default(false)
   setupStatus      SetupStatus   @default(pending_pairing)
-  destinationName  String?
-  destinationAddress String?
-  etaMinutes       Int?
+  destinationName      String?
+  destinationAddress   String?
+  destinationLatitude  Float?
+  destinationLongitude Float?
+  originLatitude       Float?
+  originLongitude      Float?
+  etaMinutes           Int?
   tripDistanceMiles    Float?
   tripDistanceRemaining Float?
   lastUpdated      DateTime      @default(now())

--- a/src/features/vehicles/api/vehicle-mappers.ts
+++ b/src/features/vehicles/api/vehicle-mappers.ts
@@ -110,6 +110,18 @@ export function mapPrismaVehicleToVehicle(prismaVehicle: PrismaVehicleWithStops)
   if (prismaVehicle.destinationAddress) {
     vehicle.destinationAddress = prismaVehicle.destinationAddress;
   }
+  if (prismaVehicle.destinationLatitude != null) {
+    vehicle.destinationLatitude = prismaVehicle.destinationLatitude;
+  }
+  if (prismaVehicle.destinationLongitude != null) {
+    vehicle.destinationLongitude = prismaVehicle.destinationLongitude;
+  }
+  if (prismaVehicle.originLatitude != null) {
+    vehicle.originLatitude = prismaVehicle.originLatitude;
+  }
+  if (prismaVehicle.originLongitude != null) {
+    vehicle.originLongitude = prismaVehicle.originLongitude;
+  }
   if (prismaVehicle.etaMinutes != null) {
     vehicle.etaMinutes = prismaVehicle.etaMinutes;
   }


### PR DESCRIPTION
## Summary

- Adds `destinationLatitude`, `destinationLongitude`, `originLatitude`, `originLongitude` as nullable `Float?` columns to the `Vehicle` model in `prisma/schema.prisma`
- Creates migration `20260328045929_add_navigation_coordinates` and applies it to the database
- Maps the 4 new fields in `vehicle-mappers.ts` using the same null-guard pattern as the existing optional trip fields

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 631 tests pass
- [x] `npx prisma migrate deploy` — migration applied successfully to Supabase
- [x] Prisma client regenerated with new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)