### PR TITLE
#208 Render driven GPS path on map

### DIFF
--- a/src/components/map/VehicleMap.tsx
+++ b/src/components/map/VehicleMap.tsx
@@ -23,10 +23,12 @@ export interface VehicleState {
 
 /** Route display configuration. */
 export interface RouteConfig {
-  /** Show the two-tone route line. */
+  /** Show the route line. */
   show?: boolean;
   /** Route coordinates as [lng, lat] pairs. */
   coordinates?: LngLat[];
+  /** True when coordinates represent a driven GPS path (not a planned nav route). */
+  isDrivenPath?: boolean;
 }
 
 /** Props for the VehicleMap component. */
@@ -67,6 +69,7 @@ export function VehicleMap({
   const speed = vehicle?.speed ?? 0;
   const showRoute = route?.show ?? false;
   const routeCoordinates = route?.coordinates;
+  const isDrivenPath = route?.isDrivenPath ?? false;
 
   // Guard against 0,0 coordinates (Tesla returns null when vehicle is asleep/offline,
   // mapper defaults to 0). Fall back to the Mapbox default center.
@@ -81,7 +84,7 @@ export function VehicleMap({
   const hasActiveRoute = showRoute && !!routeCoordinates && routeCoordinates.length >= 2;
 
   const { remainingRoute } = useRouteLayer(
-    map, mapLoaded, showRoute, routeCoordinates, markerPos,
+    map, mapLoaded, showRoute, routeCoordinates, markerPos, isDrivenPath,
   );
 
   const { mapMode, isDisabled, isOffCenter, cycleMode, recenter } = useMapFollow(

--- a/src/components/map/hooks/use-route-layer.ts
+++ b/src/components/map/hooks/use-route-layer.ts
@@ -45,19 +45,16 @@ export interface UseRouteLayerReturn {
 // ── Main hook ──────────────────────────────────────────────────────────────
 
 /**
- * Renders the navigation route as two overlapping layers for a flicker-free
- * two-tone effect:
+ * Renders a route as one or two overlapping Mapbox layers.
  *
- * 1. **Completed layer** (dim gold): Shows the full route. Set once, never
- *    updated unless the route itself changes. No flicker.
+ * **Navigation route** (two-tone): When `isDrivenPath` is false, uses two
+ * layers for a flicker-free dim/bright effect — dim gold behind the vehicle,
+ * bright gold ahead. The remaining layer updates only when the vehicle
+ * passes a new waypoint (~30s on a highway), avoiding per-tick flicker.
  *
- * 2. **Remaining layer** (bright gold): Shows from the current waypoint to
- *    the end of the route. Updated via `setData` ONLY when the vehicle
- *    passes a new waypoint (every ~30s on a highway), not on every
- *    position tick (~1s). This eliminates the flicker caused by calling
- *    `setPaintProperty('line-gradient', ...)` on every tick.
- *
- * The visual result: dim gold behind the vehicle, bright gold ahead.
+ * **Driven GPS path** (single layer): When `isDrivenPath` is true, the route
+ * represents the vehicle's accumulated GPS trail. All points are behind the
+ * vehicle, so the entire route renders as a single bright gold line.
  */
 export function useRouteLayer(
   map: React.RefObject<mapboxgl.Map | null>,
@@ -65,6 +62,7 @@ export function useRouteLayer(
   showRoute: boolean,
   routeCoordinates: LngLat[] | undefined,
   vehiclePosition: LngLat,
+  isDrivenPath = false,
 ): UseRouteLayerReturn {
   const startMarkerRef = useRef<mapboxgl.Marker | null>(null);
   const endMarkerRef = useRef<mapboxgl.Marker | null>(null);
@@ -106,7 +104,11 @@ export function useRouteLayer(
 
     const setup = () => {
       try {
-        // ── Completed layer (full route, dim) ──────────────────────────
+        // ── Completed layer ───────────────────────────────────────────
+        // For a driven GPS path: bright gold (single-layer rendering).
+        // For a nav route: dim gold (two-layer dim/bright split).
+        const completedColor = isDrivenPath ? GOLD_BRIGHT : GOLD_DIM;
+
         if (!m.getSource(COMPLETED_SOURCE)) {
           m.addSource(COMPLETED_SOURCE, {
             type: 'geojson',
@@ -123,21 +125,26 @@ export function useRouteLayer(
             source: COMPLETED_SOURCE,
             layout: { 'line-join': 'round', 'line-cap': 'round' },
             paint: {
-              'line-color': GOLD_DIM,
+              'line-color': completedColor,
               'line-width': 4,
             },
           });
+        } else {
+          m.setPaintProperty(COMPLETED_LAYER, 'line-color', completedColor);
         }
 
         // ── Remaining layer (from vehicle onward, bright) ──────────────
+        // Only used for nav routes. For driven paths, show empty data.
+        const remainingData = isDrivenPath ? EMPTY_LINE : lineFeature(stableRoute);
+
         if (!m.getSource(REMAINING_SOURCE)) {
           m.addSource(REMAINING_SOURCE, {
             type: 'geojson',
-            data: lineFeature(stableRoute),
+            data: remainingData,
           });
         } else {
           (m.getSource(REMAINING_SOURCE) as mapboxgl.GeoJSONSource)
-            .setData(lineFeature(stableRoute));
+            .setData(remainingData);
         }
         if (!m.getLayer(REMAINING_LAYER)) {
           m.addLayer({
@@ -157,7 +164,7 @@ export function useRouteLayer(
 
       layersAddedRef.current = true;
       lastWaypointIndexRef.current = -1;
-      setRemainingRoute(stableRoute);
+      setRemainingRoute(isDrivenPath ? undefined : stableRoute);
       addEndpointMarkers(m, stableRoute, startMarkerRef, endMarkerRef);
     };
 
@@ -172,10 +179,14 @@ export function useRouteLayer(
       layersAddedRef.current = false;
       lastWaypointIndexRef.current = -1;
     };
-  }, [map, mapLoaded, showRoute, stableRoute]);
+  }, [map, mapLoaded, showRoute, stableRoute, isDrivenPath]);
 
   // ── Update remaining layer when vehicle passes a new waypoint ──────────
+  // Skipped for driven GPS paths — the entire route is already rendered as
+  // a single bright line, and the "remaining" concept doesn't apply.
   useEffect(() => {
+    if (isDrivenPath) return;
+
     const m = map.current;
     if (!m || !mapLoaded || !showRoute || !stableRoute || stableRoute.length < 2) {
       return;
@@ -201,7 +212,7 @@ export function useRouteLayer(
       );
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [map, mapLoaded, showRoute, stableRoute, vehiclePosition[0], vehiclePosition[1]]);
+  }, [map, mapLoaded, showRoute, stableRoute, isDrivenPath, vehiclePosition[0], vehiclePosition[1]]);
 
   return { remainingRoute };
 }

--- a/src/features/vehicles/components/HomeScreen.tsx
+++ b/src/features/vehicles/components/HomeScreen.tsx
@@ -74,10 +74,16 @@ export function HomeScreen({ vehicles, drives, onSync, wsToken, userId }: HomeSc
 
   const isDriving = vehicle.status === 'driving';
 
-  // Prefer live route from WebSocket (decoded RouteLine from Tesla nav).
+  // Prefer live route from WebSocket (accumulated GPS path or Tesla nav polyline).
   // Fall back to stored route points from the database Drive record.
   const liveRoute = getLiveRoute(vehicle);
   const routePoints = (liveRoute && liveRoute.length >= 2) ? liveRoute : currentDrive?.routePoints;
+
+  // Detect whether the route is a driven GPS path (accumulated points ending
+  // near the vehicle) vs. a planned navigation route (ending at a distant
+  // destination). This controls how the route layer renders: driven paths use
+  // a single bright line; nav routes use the two-tone completed/remaining split.
+  const isDrivenPath = isDrivenGpsPath(routePoints, [vehicle.longitude, vehicle.latitude]);
 
   // Trip progress (0-1)
   const tripProgress =
@@ -97,7 +103,7 @@ export function HomeScreen({ vehicles, drives, onSync, wsToken, userId }: HomeSc
             heading: vehicle.heading,
             speed: vehicle.speed,
           }}
-          route={{ show: isDriving, coordinates: routePoints }}
+          route={{ show: isDriving, coordinates: routePoints, isDrivenPath }}
           center={[vehicle.longitude, vehicle.latitude]}
           zoom={12}
           fitButtonBottom={sheet.currentHeight + 20}
@@ -190,12 +196,35 @@ export function HomeScreen({ vehicles, drives, onSync, wsToken, userId }: HomeSc
 
 /**
  * Extract live route coordinates from WebSocket-merged vehicle state.
- * routeCoordinates is populated by the telemetry server from Tesla RouteLine
- * and is now a typed field on Vehicle.
+ *
+ * During active drives the telemetry server sends `routeCoordinates` as the
+ * accumulated GPS path (driven route). When Tesla's built-in navigation is
+ * active, `routeCoordinates` may instead contain the planned nav polyline.
  */
 function getLiveRoute(vehicle: Vehicle): [number, number][] | undefined {
   if (vehicle.routeCoordinates && vehicle.routeCoordinates.length >= 2) {
     return vehicle.routeCoordinates;
   }
   return undefined;
+}
+
+/**
+ * Determine whether a route represents a driven GPS path (accumulated points)
+ * rather than a planned navigation polyline.
+ *
+ * Heuristic: if the last coordinate in the route is within ~100 m of the
+ * vehicle's current position, the route is a driven path (the backend appends
+ * the latest GPS fix). A planned nav route ends at the destination, which is
+ * typically far away.
+ */
+function isDrivenGpsPath(
+  route: [number, number][] | undefined,
+  vehiclePos: [number, number],
+): boolean {
+  if (!route || route.length < 2) return false;
+  const last = route[route.length - 1];
+  const dlng = last[0] - vehiclePos[0];
+  const dlat = last[1] - vehiclePos[1];
+  // ~0.001 degrees is roughly 100 m at mid-latitudes
+  return (dlng * dlng + dlat * dlat) < 0.001 * 0.001;
 }


### PR DESCRIPTION
## Summary

Closes #208

The backend telemetry server now streams accumulated GPS route points as `routeCoordinates` in `vehicle_update` WebSocket messages during active drives (tnando/my-robo-taxi-telemetry#117, tnando/my-robo-taxi-telemetry#118). Previously, `routeCoordinates` only contained Tesla's planned navigation polyline (RouteLine), which required Tesla's built-in nav to be active.

**What changed:**

- **Route layer rendering (`use-route-layer.ts`)**: Added `isDrivenPath` parameter. When the route is a driven GPS path, the entire route renders as a single bright gold line (all points are behind the vehicle). When it's a planned nav route, the existing two-tone dim/bright split is preserved. The "remaining" layer is set to empty data for driven paths, and the waypoint-tracking effect is skipped entirely.

- **Driven path detection (`HomeScreen.tsx`)**: Added `isDrivenGpsPath()` heuristic — if the last coordinate in the route is within ~100 m of the vehicle's current position, it's a driven GPS path (the backend appends the latest GPS fix as the last point). A planned nav route ends at the destination, which is far from the vehicle.

- **Prop threading (`VehicleMap.tsx`)**: Added `isDrivenPath` to `RouteConfig` interface and threaded it through to `useRouteLayer`.

**What already worked (no changes needed):**

- `getLiveRoute()` correctly extracts `routeCoordinates` from vehicle state — `[lng, lat]` tuples match Mapbox expectations
- Route display priority (`liveRoute ?? currentDrive.routePoints`) works for both data sources
- `useVehicleStream` shallow-merges WebSocket updates, correctly replacing (not appending) the full `routeCoordinates` array each tick
- DB fallback to `currentDrive.routePoints` works since the backend now incrementally persists route points during drives

## Test plan

- [ ] Verify driven GPS path renders as a single bright gold line during an active drive
- [ ] Verify planned nav route (Tesla nav active) still renders with the two-tone dim/bright split
- [ ] Verify route clears when drive ends (vehicle transitions from `driving` to `parked`)
- [ ] Verify fallback to `currentDrive.routePoints` from DB when no live WebSocket route is available
- [ ] Verify start/end markers appear correctly for both route types


🤖 Generated with [Claude Code](https://claude.com/claude-code)