### PR TITLE
#216 Fix origin address and route rendering for active drives

### DIFF
--- a/__tests__/features/vehicles/components/DrivingHalfContent.test.tsx
+++ b/__tests__/features/vehicles/components/DrivingHalfContent.test.tsx
@@ -82,13 +82,15 @@ describe('DrivingHalfContent', () => {
       expect(screen.getByText('Downtown')).toBeInTheDocument();
     });
 
-    it('falls back to origin coordinates when drive is absent', () => {
+    it('shows "Current location" when drive is absent (ignores Tesla nav origin)', () => {
       render(
         <DrivingHalfContent
           vehicle={makeVehicle({ originLatitude: 30.1234, originLongitude: -97.5678 })}
         />,
       );
-      expect(screen.getByText('30.1234, -97.5678')).toBeInTheDocument();
+      // Should NOT fall back to vehicle.originLatitude/originLongitude
+      expect(screen.queryByText('30.1234, -97.5678')).not.toBeInTheDocument();
+      expect(screen.getByText('Current location')).toBeInTheDocument();
     });
 
     it('shows "Current location" when no drive or coordinates are available', () => {

--- a/src/features/vehicles/components/DrivingHalfContent.tsx
+++ b/src/features/vehicles/components/DrivingHalfContent.tsx
@@ -14,15 +14,14 @@ export interface DrivingHalfContentProps {
 }
 
 /**
- * Derive a human-readable start label from drive record and/or vehicle state.
- * Prefers the stored drive address; falls back to live origin coordinates.
+ * Derive a human-readable start label from the drive record.
+ * Uses the drive's start address or location name — never falls back to
+ * vehicle.originLatitude/originLongitude, which reflects Tesla's nav origin
+ * (not necessarily where the drive actually started).
  */
-function getStartLabel(vehicle: Vehicle, currentDrive?: Drive): string {
+function getStartLabel(_vehicle: Vehicle, currentDrive?: Drive): string {
   if (currentDrive?.startAddress) return currentDrive.startAddress;
   if (currentDrive?.startLocation) return currentDrive.startLocation;
-  if (vehicle.originLatitude != null && vehicle.originLongitude != null) {
-    return `${vehicle.originLatitude.toFixed(4)}, ${vehicle.originLongitude.toFixed(4)}`;
-  }
   return 'Current location';
 }
 

--- a/src/features/vehicles/components/DrivingPeekContent.tsx
+++ b/src/features/vehicles/components/DrivingPeekContent.tsx
@@ -31,15 +31,14 @@ function getDestinationLabel(vehicle: Vehicle): string {
 }
 
 /**
- * Derive a human-readable origin label. Prefers the drive record's address
- * (populated by backend geocoding); falls back to coordinates from telemetry.
+ * Derive a human-readable origin label from the drive record.
+ * Uses the drive's start address or location name — never falls back to
+ * vehicle.originLatitude/originLongitude, which reflects Tesla's nav origin
+ * (not necessarily where the drive actually started).
  */
-function getOriginLabel(vehicle: Vehicle, currentDrive?: Drive): string {
+function getOriginLabel(_vehicle: Vehicle, currentDrive?: Drive): string {
   if (currentDrive?.startAddress) return currentDrive.startAddress;
   if (currentDrive?.startLocation) return currentDrive.startLocation;
-  if (vehicle.originLatitude != null && vehicle.originLongitude != null) {
-    return `${vehicle.originLatitude.toFixed(4)}, ${vehicle.originLongitude.toFixed(4)}`;
-  }
   return 'Origin';
 }
 

--- a/src/features/vehicles/components/HomeScreen.tsx
+++ b/src/features/vehicles/components/HomeScreen.tsx
@@ -74,16 +74,16 @@ export function HomeScreen({ vehicles, drives, onSync, wsToken, userId }: HomeSc
 
   const isDriving = vehicle.status === 'driving';
 
-  // Prefer live route from WebSocket (accumulated GPS path or Tesla nav polyline).
-  // Fall back to stored route points from the database Drive record.
+  // The backend sends two distinct route fields via WebSocket:
+  // - routeCoordinates: accumulated GPS track (driven path)
+  // - navRouteCoordinates: Tesla's planned navigation polyline
+  // Prefer the live driven GPS path; fall back to stored route points.
   const liveRoute = getLiveRoute(vehicle);
   const routePoints = (liveRoute && liveRoute.length >= 2) ? liveRoute : currentDrive?.routePoints;
 
-  // Detect whether the route is a driven GPS path (accumulated points ending
-  // near the vehicle) vs. a planned navigation route (ending at a distant
-  // destination). This controls how the route layer renders: driven paths use
-  // a single bright line; nav routes use the two-tone completed/remaining split.
-  const isDrivenPath = isDrivenGpsPath(routePoints, [vehicle.longitude, vehicle.latitude]);
+  // The driven GPS path is explicitly identified by the backend — no heuristic needed.
+  // When we have live route coordinates, they are always the driven path.
+  const isDrivenPath = !!(liveRoute && liveRoute.length >= 2);
 
   // Trip progress (0-1)
   const tripProgress =
@@ -195,11 +195,11 @@ export function HomeScreen({ vehicles, drives, onSync, wsToken, userId }: HomeSc
 }
 
 /**
- * Extract live route coordinates from WebSocket-merged vehicle state.
+ * Extract the driven GPS path from WebSocket-merged vehicle state.
  *
- * During active drives the telemetry server sends `routeCoordinates` as the
- * accumulated GPS path (driven route). When Tesla's built-in navigation is
- * active, `routeCoordinates` may instead contain the planned nav polyline.
+ * The backend now explicitly sends `routeCoordinates` as the accumulated GPS
+ * track (driven path only). The planned nav polyline is sent separately as
+ * `navRouteCoordinates`.
  */
 function getLiveRoute(vehicle: Vehicle): [number, number][] | undefined {
   if (vehicle.routeCoordinates && vehicle.routeCoordinates.length >= 2) {
@@ -209,22 +209,14 @@ function getLiveRoute(vehicle: Vehicle): [number, number][] | undefined {
 }
 
 /**
- * Determine whether a route represents a driven GPS path (accumulated points)
- * rather than a planned navigation polyline.
+ * Extract Tesla's planned navigation polyline from WebSocket-merged vehicle state.
  *
- * Heuristic: if the last coordinate in the route is within ~100 m of the
- * vehicle's current position, the route is a driven path (the backend appends
- * the latest GPS fix). A planned nav route ends at the destination, which is
- * typically far away.
+ * This is the route ahead — from the vehicle's current position to the
+ * destination. Available only when Tesla's built-in navigation is active.
  */
-function isDrivenGpsPath(
-  route: [number, number][] | undefined,
-  vehiclePos: [number, number],
-): boolean {
-  if (!route || route.length < 2) return false;
-  const last = route[route.length - 1];
-  const dlng = last[0] - vehiclePos[0];
-  const dlat = last[1] - vehiclePos[1];
-  // ~0.001 degrees is roughly 100 m at mid-latitudes
-  return (dlng * dlng + dlat * dlat) < 0.001 * 0.001;
+function getLiveNavRoute(vehicle: Vehicle): [number, number][] | undefined {
+  if (vehicle.navRouteCoordinates && vehicle.navRouteCoordinates.length >= 2) {
+    return vehicle.navRouteCoordinates;
+  }
+  return undefined;
 }

--- a/src/types/vehicle.ts
+++ b/src/types/vehicle.ts
@@ -67,6 +67,8 @@ export interface Vehicle {
   stops?: TripStop[];
   /** Navigation fields — populated via WebSocket real-time updates from Tesla RouteLine/nav data. */
   routeCoordinates?: [number, number][];
+  /** Tesla's planned navigation polyline (route to destination). */
+  navRouteCoordinates?: [number, number][];
   destinationLatitude?: number;
   destinationLongitude?: number;
   originLatitude?: number;


### PR DESCRIPTION
## Summary

- **Fix origin address fallback**: Removed `vehicle.originLatitude/originLongitude` fallback from `getOriginLabel()` (DrivingPeekContent) and `getStartLabel()` (DrivingHalfContent). These Tesla nav origin values showed incorrect addresses (e.g., "3104 Knox Street, Dallas") instead of the user's actual start location. Now only uses `currentDrive.startAddress` or `startLocation`.
- **Separate nav/driven route rendering**: The backend now sends `routeCoordinates` (driven GPS path) and `navRouteCoordinates` (planned nav polyline) as distinct fields. Removed the `isDrivenGpsPath()` distance heuristic and replaced it with explicit route type identification. Added `getLiveNavRoute()` extractor and `navRouteCoordinates` to the Vehicle type for future use.
- **Updated test**: Fixed `DrivingHalfContent.test.tsx` to verify that Tesla nav origin coordinates are no longer used as start label fallback.

## Test plan
- [ ] Verify origin label shows drive record address (not Tesla nav origin) during active drives
- [ ] Verify "Origin" / "Current location" fallback when no drive record is available
- [ ] Verify driven GPS path renders as bright gold single-layer line on the map
- [ ] Verify existing unit tests pass with updated expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)