### PR TITLE
#221 #222 Format FSD miles and persist nav route across park/drive transitions

### DIFF
--- a/src/features/vehicles/components/DrivingHalfContent.tsx
+++ b/src/features/vehicles/components/DrivingHalfContent.tsx
@@ -82,7 +82,7 @@ export function DrivingHalfContent({ vehicle, currentDrive }: DrivingHalfContent
         </div>
         <div>
           <p className="text-text-muted text-xs font-medium uppercase tracking-wider mb-1">FSD Today</p>
-          <p className="text-gold text-sm tabular-nums font-medium">{vehicle.fsdMilesToday} mi</p>
+          <p className="text-gold text-sm tabular-nums font-medium">{vehicle.fsdMilesToday.toFixed(1)} mi</p>
         </div>
       </div>
 

--- a/src/features/vehicles/components/HomeScreen.tsx
+++ b/src/features/vehicles/components/HomeScreen.tsx
@@ -74,11 +74,17 @@ export function HomeScreen({ vehicles, drives, onSync, wsToken, userId }: HomeSc
 
   const isDriving = vehicle.status === 'driving';
 
+  // Show route when nav is active OR vehicle is driving with route data.
+  // This prevents the route from disappearing during brief park→drive transitions
+  // (e.g. red lights) when Tesla nav is still active.
+  const navRoute = getLiveNavRoute(vehicle);
+  const hasNavRoute = !!(navRoute && navRoute.length >= 2);
+  const showRoute = isDriving || hasNavRoute;
+
   // The backend sends two distinct route fields via WebSocket:
   // - navRouteCoordinates: Tesla's planned navigation polyline (route to destination)
   // - routeCoordinates: accumulated GPS track (driven path)
   // Prefer the nav route (planned path ahead); fall back to driven GPS path or DB route points.
-  const navRoute = getLiveNavRoute(vehicle);
   const liveRoute = getLiveRoute(vehicle);
   const routePoints = (navRoute && navRoute.length >= 2)
     ? navRoute
@@ -105,7 +111,7 @@ export function HomeScreen({ vehicles, drives, onSync, wsToken, userId }: HomeSc
             heading: vehicle.heading,
             speed: vehicle.speed,
           }}
-          route={{ show: isDriving, coordinates: routePoints, isDrivenPath }}
+          route={{ show: showRoute, coordinates: routePoints, isDrivenPath }}
           center={[vehicle.longitude, vehicle.latitude]}
           zoom={12}
           fitButtonBottom={sheet.currentHeight + 20}

--- a/src/features/vehicles/components/ParkedHalfContent.tsx
+++ b/src/features/vehicles/components/ParkedHalfContent.tsx
@@ -38,7 +38,7 @@ export function ParkedHalfContent({ vehicle }: ParkedHalfContentProps) {
         </div>
         <div>
           <p className="text-text-muted text-xs font-medium uppercase tracking-wider mb-1">FSD Today</p>
-          <p className="text-gold text-sm tabular-nums font-medium">{vehicle.fsdMilesToday} mi</p>
+          <p className="text-gold text-sm tabular-nums font-medium">{vehicle.fsdMilesToday.toFixed(1)} mi</p>
         </div>
         <div>
           <p className="text-text-muted text-xs font-medium uppercase tracking-wider mb-1">Heading</p>


### PR DESCRIPTION
## Summary
- **#221** — Format `vehicle.fsdMilesToday` with `.toFixed(1)` in both `ParkedHalfContent` and `DrivingHalfContent` so it displays "3083.6 mi" instead of the raw float "3083.594482421875 mi".
- **#222** — Change route visibility logic in `HomeScreen` from `show: isDriving` to `show: showRoute` where `showRoute = isDriving || hasNavRoute`. This keeps the map route visible whenever Tesla nav is active, preventing route destruction/recreation during brief park→drive transitions (e.g. stopping at a red light).

## Test plan
- [ ] Verify FSD Today shows 1 decimal place on parked vehicle bottom sheet (half state)
- [ ] Verify FSD Today shows 1 decimal place on driving vehicle bottom sheet (half state)
- [ ] Simulate a park→drive transition while nav is active and confirm the route stays visible on the map
- [ ] Confirm route disappears when nav is genuinely inactive (no `navRouteCoordinates` on the vehicle)
- [ ] Confirm no TypeScript errors with `npm run typecheck`

Closes #221
Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)