### PR TITLE
Add skeleton loading for route transition fields

### DIFF
--- a/__tests__/components/ui/Skeleton.test.tsx
+++ b/__tests__/components/ui/Skeleton.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+
+import { Skeleton } from '@/components/ui/Skeleton';
+
+describe('Skeleton', () => {
+  it('renders with role="status" and aria-label', () => {
+    const { container } = render(<Skeleton />);
+    const el = container.querySelector('[role="status"]');
+    expect(el).toBeTruthy();
+    expect(el?.getAttribute('aria-label')).toBe('Loading');
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<Skeleton className="h-4 w-24" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toContain('h-4');
+    expect(el.className).toContain('w-24');
+  });
+
+  it('contains shimmer animation child', () => {
+    const { container } = render(<Skeleton />);
+    const shimmer = container.querySelector('.animate-shimmer');
+    expect(shimmer).toBeTruthy();
+  });
+});

--- a/__tests__/features/vehicles/components/DrivingHalfContent.test.tsx
+++ b/__tests__/features/vehicles/components/DrivingHalfContent.test.tsx
@@ -149,4 +149,18 @@ describe('DrivingHalfContent', () => {
     render(<DrivingHalfContent vehicle={makeVehicle({ odometerMiles: 12345 })} />);
     expect(screen.getByText('12,345 mi')).toBeInTheDocument();
   });
+
+  it('shows skeletons for start and destination when route is transitioning', () => {
+    const { container } = render(
+      <DrivingHalfContent
+        vehicle={makeVehicle({ destinationName: 'Airport' })}
+        currentDrive={makeDrive({ startAddress: '100 Oak St' })}
+        isRouteTransitioning
+      />,
+    );
+    expect(screen.queryByText('100 Oak St')).not.toBeInTheDocument();
+    expect(screen.queryByText('Airport')).not.toBeInTheDocument();
+    const skeletons = container.querySelectorAll('[aria-label="Loading"]');
+    expect(skeletons.length).toBe(2);
+  });
 });

--- a/__tests__/features/vehicles/components/DrivingPeekContent.test.tsx
+++ b/__tests__/features/vehicles/components/DrivingPeekContent.test.tsx
@@ -102,4 +102,16 @@ describe('DrivingPeekContent', () => {
     );
     expect(screen.getByText('Destination')).toBeInTheDocument();
   });
+
+  it('shows skeleton instead of destination text when route is transitioning', () => {
+    const { container } = render(
+      <DrivingPeekContent
+        vehicle={makeVehicle({ destinationName: 'Whole Foods' })}
+        tripProgress={0.3}
+        isRouteTransitioning
+      />,
+    );
+    expect(screen.queryByText('Heading to Whole Foods')).not.toBeInTheDocument();
+    expect(container.querySelector('[aria-label="Loading"]')).toBeTruthy();
+  });
 });

--- a/__tests__/features/vehicles/components/StatRow.test.tsx
+++ b/__tests__/features/vehicles/components/StatRow.test.tsx
@@ -47,4 +47,24 @@ describe('StatRow', () => {
     const batteryValue = screen.getByText('15%');
     expect(batteryValue.className).toContain('text-battery-low');
   });
+
+  it('shows skeleton for ETA when route is transitioning', () => {
+    const { container } = render(
+      <StatRow etaMinutes={12} speed={65} chargeLevel={55} isRouteTransitioning />,
+    );
+    // ETA value should be replaced by skeleton
+    expect(screen.queryByText('12 min')).not.toBeInTheDocument();
+    // ETA label still visible
+    expect(screen.getByText('ETA')).toBeInTheDocument();
+    // Skeleton element present
+    expect(container.querySelector('[aria-label="Loading"]')).toBeTruthy();
+  });
+
+  it('does not show skeleton when not transitioning', () => {
+    const { container } = render(
+      <StatRow etaMinutes={12} speed={65} chargeLevel={55} isRouteTransitioning={false} />,
+    );
+    expect(screen.getByText('12 min')).toBeInTheDocument();
+    expect(container.querySelector('[aria-label="Loading"]')).toBeNull();
+  });
 });

--- a/__tests__/features/vehicles/components/TripProgressBar.test.tsx
+++ b/__tests__/features/vehicles/components/TripProgressBar.test.tsx
@@ -50,4 +50,20 @@ describe('TripProgressBar', () => {
     const pulsingDot = container.querySelector('.animate-gold-glow');
     expect(pulsingDot).toBeTruthy();
   });
+
+  it('shows skeletons for labels when route is transitioning', () => {
+    const { container } = render(
+      <TripProgressBar
+        progress={0.5}
+        stops={[]}
+        originLabel="Home"
+        destinationLabel="Work"
+        isRouteTransitioning
+      />,
+    );
+    expect(screen.queryByText('Home')).not.toBeInTheDocument();
+    expect(screen.queryByText('Work')).not.toBeInTheDocument();
+    const skeletons = container.querySelectorAll('[aria-label="Loading"]');
+    expect(skeletons.length).toBe(2);
+  });
 });

--- a/__tests__/features/vehicles/hooks/use-route-transition.test.ts
+++ b/__tests__/features/vehicles/hooks/use-route-transition.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { useRouteTransition } from '@/features/vehicles/hooks/use-route-transition';
+
+describe('useRouteTransition', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts as not transitioning', () => {
+    const coords: [number, number][] = [[0, 0], [1, 1]];
+    const { result } = renderHook(() => useRouteTransition(coords, 'Home', 10));
+    expect(result.current.isRouteTransitioning).toBe(false);
+  });
+
+  it('transitions when route fingerprint changes', () => {
+    const route1: [number, number][] = [[0, 0], [1, 1]];
+    const route2: [number, number][] = [[0, 0], [2, 2], [3, 3]];
+
+    const { result, rerender } = renderHook(
+      ({ coords, dest, eta }) => useRouteTransition(coords, dest, eta),
+      { initialProps: { coords: route1, dest: 'Home', eta: 10 } },
+    );
+
+    expect(result.current.isRouteTransitioning).toBe(false);
+
+    // Route changes — should start transitioning
+    rerender({ coords: route2, dest: 'Home', eta: 10 });
+    expect(result.current.isRouteTransitioning).toBe(true);
+  });
+
+  it('clears transition when destination name changes', () => {
+    const route1: [number, number][] = [[0, 0], [1, 1]];
+    const route2: [number, number][] = [[0, 0], [2, 2], [3, 3]];
+
+    const { result, rerender } = renderHook(
+      ({ coords, dest, eta }) => useRouteTransition(coords, dest, eta),
+      { initialProps: { coords: route1, dest: 'Home', eta: 10 } },
+    );
+
+    // Route changes — transitioning starts
+    rerender({ coords: route2, dest: 'Home', eta: 10 });
+    expect(result.current.isRouteTransitioning).toBe(true);
+
+    // Destination updates — transitioning clears
+    rerender({ coords: route2, dest: 'Office', eta: 10 });
+    expect(result.current.isRouteTransitioning).toBe(false);
+  });
+
+  it('clears transition when ETA changes', () => {
+    const route1: [number, number][] = [[0, 0], [1, 1]];
+    const route2: [number, number][] = [[0, 0], [2, 2], [3, 3]];
+
+    const { result, rerender } = renderHook(
+      ({ coords, dest, eta }) => useRouteTransition(coords, dest, eta),
+      { initialProps: { coords: route1, dest: 'Home', eta: 10 } },
+    );
+
+    rerender({ coords: route2, dest: 'Home', eta: 10 });
+    expect(result.current.isRouteTransitioning).toBe(true);
+
+    // ETA updates — transitioning clears
+    rerender({ coords: route2, dest: 'Home', eta: 15 });
+    expect(result.current.isRouteTransitioning).toBe(false);
+  });
+
+  it('auto-clears after timeout', () => {
+    vi.useFakeTimers();
+
+    const route1: [number, number][] = [[0, 0], [1, 1]];
+    const route2: [number, number][] = [[0, 0], [2, 2], [3, 3]];
+
+    const { result, rerender } = renderHook(
+      ({ coords, dest, eta }) => useRouteTransition(coords, dest, eta),
+      { initialProps: { coords: route1, dest: 'Home', eta: 10 } },
+    );
+
+    rerender({ coords: route2, dest: 'Home', eta: 10 });
+    expect(result.current.isRouteTransitioning).toBe(true);
+
+    // Advance past the 2s timeout
+    act(() => { vi.advanceTimersByTime(2100); });
+    expect(result.current.isRouteTransitioning).toBe(false);
+
+    vi.useRealTimers();
+  });
+
+  it('does not transition when route is undefined', () => {
+    const { result, rerender } = renderHook(
+      ({ coords, dest, eta }) => useRouteTransition(coords, dest, eta),
+      { initialProps: { coords: undefined as [number, number][] | undefined, dest: 'Home', eta: 10 } },
+    );
+
+    expect(result.current.isRouteTransitioning).toBe(false);
+
+    // Still undefined — no transition
+    rerender({ coords: undefined, dest: 'Home', eta: 10 });
+    expect(result.current.isRouteTransitioning).toBe(false);
+  });
+
+  it('does not transition when coordinates are identical', () => {
+    const route: [number, number][] = [[0, 0], [1, 1]];
+
+    const { result, rerender } = renderHook(
+      ({ coords, dest, eta }) => useRouteTransition(coords, dest, eta),
+      { initialProps: { coords: route, dest: 'Home', eta: 10 } },
+    );
+
+    // Same reference — no change
+    rerender({ coords: route, dest: 'Home', eta: 10 });
+    expect(result.current.isRouteTransitioning).toBe(false);
+
+    // New array, same fingerprint — no change
+    const routeCopy: [number, number][] = [[0, 0], [1, 1]];
+    rerender({ coords: routeCopy, dest: 'Home', eta: 10 });
+    expect(result.current.isRouteTransitioning).toBe(false);
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -169,3 +169,13 @@ body {
 .animate-shake {
   animation: shake 0.5s ease-in-out;
 }
+
+/* Shimmer animation for skeleton loading placeholders */
+@keyframes shimmer {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+.animate-shimmer {
+  animation: shimmer 1.5s ease-in-out infinite;
+}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,27 @@
+/** Props for the Skeleton loading placeholder. */
+export interface SkeletonProps {
+  /** Additional Tailwind classes for width/height (e.g., "w-24 h-4"). */
+  className?: string;
+}
+
+/**
+ * Shimmer loading placeholder with a subtle gold-tinted sweep.
+ * Matches the dark theme — base is bg-elevated with a translucent gold highlight.
+ */
+export function Skeleton({ className = '' }: SkeletonProps) {
+  return (
+    <div
+      className={`relative overflow-hidden rounded bg-bg-elevated ${className}`}
+      role="status"
+      aria-label="Loading"
+    >
+      <div
+        className="absolute inset-0 animate-shimmer"
+        style={{
+          background:
+            'linear-gradient(90deg, transparent 0%, rgba(201, 168, 76, 0.08) 50%, transparent 100%)',
+        }}
+      />
+    </div>
+  );
+}

--- a/src/features/vehicles/components/DrivingHalfContent.tsx
+++ b/src/features/vehicles/components/DrivingHalfContent.tsx
@@ -1,6 +1,8 @@
 import type { Vehicle } from '@/types/vehicle';
 import type { Drive } from '@/types/drive';
 
+import { Skeleton } from '@/components/ui/Skeleton';
+
 import { ClimateCard, climateCardPropsFromVehicle } from './ClimateCard';
 import { VehicleDetailsBlock } from './VehicleDetailsBlock';
 import { StopsList } from './StopsList';
@@ -11,6 +13,8 @@ export interface DrivingHalfContentProps {
   vehicle: Vehicle;
   /** The current drive (for start location). */
   currentDrive?: Drive;
+  /** Whether route-related fields are transitioning (show skeleton). */
+  isRouteTransitioning?: boolean;
 }
 
 /**
@@ -40,7 +44,11 @@ function getDestinationLabel(vehicle: Vehicle): string {
  * Extended bottom sheet content when vehicle is driving (half state).
  * Start/destination, stops, vehicle details, odometer, FSD, temps, timestamp.
  */
-export function DrivingHalfContent({ vehicle, currentDrive }: DrivingHalfContentProps) {
+export function DrivingHalfContent({
+  vehicle,
+  currentDrive,
+  isRouteTransitioning,
+}: DrivingHalfContentProps) {
   const startLabel = getStartLabel(vehicle, currentDrive);
   const destinationLabel = getDestinationLabel(vehicle);
 
@@ -51,16 +59,24 @@ export function DrivingHalfContent({ vehicle, currentDrive }: DrivingHalfContent
       {/* Start / Destination */}
       <div className="mb-5">
         <p className="text-text-muted text-xs font-medium uppercase tracking-wider mb-1">Start</p>
-        <p className="text-text-primary text-sm font-light">{startLabel}</p>
+        {isRouteTransitioning ? (
+          <Skeleton className="h-4 w-44" />
+        ) : (
+          <p className="text-text-primary text-sm font-light">{startLabel}</p>
+        )}
       </div>
 
       <div className="mb-5">
         <p className="text-text-muted text-xs font-medium uppercase tracking-wider mb-1">Destination</p>
-        <p className="text-text-primary text-sm font-light">
-          {vehicle.destinationAddress
-            ? `${destinationLabel} — ${vehicle.destinationAddress}`
-            : destinationLabel}
-        </p>
+        {isRouteTransitioning ? (
+          <Skeleton className="h-4 w-56" />
+        ) : (
+          <p className="text-text-primary text-sm font-light">
+            {vehicle.destinationAddress
+              ? `${destinationLabel} — ${vehicle.destinationAddress}`
+              : destinationLabel}
+          </p>
+        )}
       </div>
 
       {/* Stops */}

--- a/src/features/vehicles/components/DrivingPeekContent.tsx
+++ b/src/features/vehicles/components/DrivingPeekContent.tsx
@@ -2,6 +2,7 @@ import type { Vehicle } from '@/types/vehicle';
 import type { Drive } from '@/types/drive';
 
 import { StatusBadge } from '@/components/ui/StatusBadge';
+import { Skeleton } from '@/components/ui/Skeleton';
 
 import { GearIndicator } from './GearIndicator';
 import { TripProgressBar } from './TripProgressBar';
@@ -15,6 +16,8 @@ export interface DrivingPeekContentProps {
   currentDrive?: Drive;
   /** Trip completion fraction (0-1). */
   tripProgress: number;
+  /** Whether route-related fields are transitioning (show skeleton). */
+  isRouteTransitioning?: boolean;
 }
 
 /**
@@ -51,6 +54,7 @@ export function DrivingPeekContent({
   vehicle,
   currentDrive,
   tripProgress,
+  isRouteTransitioning,
 }: DrivingPeekContentProps) {
   const destinationLabel = getDestinationLabel(vehicle);
 
@@ -64,9 +68,13 @@ export function DrivingPeekContent({
         </div>
         <StatusBadge status="driving" />
       </div>
-      <p className="text-sm text-gold font-light mb-3">
-        {destinationLabel ? `Heading to ${destinationLabel}` : 'Driving'}
-      </p>
+      {isRouteTransitioning ? (
+        <Skeleton className="h-4 w-40 mb-3" />
+      ) : (
+        <p className="text-sm text-gold font-light mb-3">
+          {destinationLabel ? `Heading to ${destinationLabel}` : 'Driving'}
+        </p>
+      )}
 
       {/* Trip progress bar */}
       <TripProgressBar
@@ -74,6 +82,7 @@ export function DrivingPeekContent({
         stops={vehicle.stops ?? []}
         originLabel={getOriginLabel(vehicle, currentDrive)}
         destinationLabel={destinationLabel || 'Destination'}
+        isRouteTransitioning={isRouteTransitioning}
       />
 
       {/* Key stats row */}
@@ -81,6 +90,7 @@ export function DrivingPeekContent({
         etaMinutes={vehicle.etaMinutes}
         speed={vehicle.speed}
         chargeLevel={vehicle.chargeLevel}
+        isRouteTransitioning={isRouteTransitioning}
       />
     </div>
   );

--- a/src/features/vehicles/components/HomeScreen.tsx
+++ b/src/features/vehicles/components/HomeScreen.tsx
@@ -14,6 +14,7 @@ import { useBottomSheet } from '../hooks/use-bottom-sheet';
 import { useBackgroundSync } from '../hooks/use-background-sync';
 import { usePullToRefresh } from '../hooks/use-pull-to-refresh';
 import { useVehicleStream } from '../hooks/use-vehicle-stream';
+import { useRouteTransition } from '../hooks/use-route-transition';
 import { VehicleDotSelector } from './VehicleDotSelector';
 import { DrivingPeekContent } from './DrivingPeekContent';
 import { ParkedPeekContent } from './ParkedPeekContent';
@@ -70,6 +71,13 @@ export function HomeScreen({ vehicles, drives, onSync, wsToken, userId }: HomeSc
   const currentDrive = useMemo(
     () => selectCurrentDrive(drives, vehicle.id),
     [vehicle.id, drives],
+  );
+
+  // Detect route polyline changes to show skeleton loading on stale text fields
+  const { isRouteTransitioning } = useRouteTransition(
+    vehicle.navRouteCoordinates,
+    vehicle.destinationName,
+    vehicle.etaMinutes,
   );
 
   // Derive driving status from gear — don't rely on the backend status field
@@ -183,6 +191,7 @@ export function HomeScreen({ vehicles, drives, onSync, wsToken, userId }: HomeSc
             vehicle={vehicle}
             currentDrive={currentDrive}
             tripProgress={tripProgress}
+            isRouteTransitioning={isRouteTransitioning}
           />
         ) : (
           <ParkedPeekContent vehicle={vehicle} />
@@ -191,7 +200,7 @@ export function HomeScreen({ vehicles, drives, onSync, wsToken, userId }: HomeSc
         {/* Half content */}
         {showHalf && (
           isDriving ? (
-            <DrivingHalfContent vehicle={vehicle} currentDrive={currentDrive} />
+            <DrivingHalfContent vehicle={vehicle} currentDrive={currentDrive} isRouteTransitioning={isRouteTransitioning} />
           ) : (
             <ParkedHalfContent vehicle={vehicle} />
           )

--- a/src/features/vehicles/components/StatRow.tsx
+++ b/src/features/vehicles/components/StatRow.tsx
@@ -1,4 +1,5 @@
 import { getBatteryTextColor } from '@/lib/vehicle-helpers';
+import { Skeleton } from '@/components/ui/Skeleton';
 
 /** Props for the StatRow component. */
 export interface StatRowProps {
@@ -8,19 +9,26 @@ export interface StatRowProps {
   speed: number;
   /** Battery charge level (0-100). */
   chargeLevel: number;
+  /** Whether route-related fields are transitioning (show skeleton). */
+  isRouteTransitioning?: boolean;
 }
 
 /**
  * Key stats row with dividers — ETA / Speed / Battery.
  * ETA column only renders when etaMinutes is provided (driving state).
+ * Shows skeleton for ETA during route transitions.
  */
-export function StatRow({ etaMinutes, speed, chargeLevel }: StatRowProps) {
+export function StatRow({ etaMinutes, speed, chargeLevel, isRouteTransitioning }: StatRowProps) {
   return (
     <div className="flex items-center justify-between mb-3">
       {etaMinutes != null && (
         <>
           <div className="text-center flex-1">
-            <p className="text-xl font-semibold tabular-nums text-text-primary">{etaMinutes} min</p>
+            {isRouteTransitioning ? (
+              <Skeleton className="h-6 w-16 mx-auto mb-0.5" />
+            ) : (
+              <p className="text-xl font-semibold tabular-nums text-text-primary">{etaMinutes} min</p>
+            )}
             <p className="text-[10px] text-text-muted font-medium uppercase tracking-wider">ETA</p>
           </div>
           <div className="w-px h-8 bg-border-default" />

--- a/src/features/vehicles/components/TripProgressBar.tsx
+++ b/src/features/vehicles/components/TripProgressBar.tsx
@@ -1,5 +1,7 @@
 import type { TripStop } from '@/types/vehicle';
 
+import { Skeleton } from '@/components/ui/Skeleton';
+
 /** Props for the TripProgressBar component. */
 export interface TripProgressBarProps {
   /** Trip completion fraction (0-1). */
@@ -10,6 +12,8 @@ export interface TripProgressBarProps {
   originLabel: string;
   /** Destination location label. */
   destinationLabel: string;
+  /** Whether route-related fields are transitioning (show skeleton). */
+  isRouteTransitioning?: boolean;
 }
 
 /**
@@ -21,6 +25,7 @@ export function TripProgressBar({
   stops,
   originLabel,
   destinationLabel,
+  isRouteTransitioning,
 }: TripProgressBarProps) {
   return (
     <div className="mb-3">
@@ -67,8 +72,16 @@ export function TripProgressBar({
       {/* Labels below the bar */}
       <div className="relative mt-1.5">
         <div className="flex justify-between">
-          <span className="text-[10px] text-text-muted font-light">{originLabel}</span>
-          <span className="text-[10px] text-text-muted font-light">{destinationLabel}</span>
+          {isRouteTransitioning ? (
+            <Skeleton className="h-3 w-20" />
+          ) : (
+            <span className="text-[10px] text-text-muted font-light">{originLabel}</span>
+          )}
+          {isRouteTransitioning ? (
+            <Skeleton className="h-3 w-24" />
+          ) : (
+            <span className="text-[10px] text-text-muted font-light">{destinationLabel}</span>
+          )}
         </div>
         {/* Stop labels positioned below their markers */}
         {stops.map((stop, i) => {

--- a/src/features/vehicles/hooks/use-route-transition.ts
+++ b/src/features/vehicles/hooks/use-route-transition.ts
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+/** Timeout (ms) before the transitioning state auto-clears. */
+const TRANSITION_TIMEOUT_MS = 2000;
+
+/**
+ * Fingerprint a route polyline by its length, first, and last coordinate.
+ * Returns null for empty/undefined routes.
+ */
+function routeFingerprint(coords: [number, number][] | undefined): string | null {
+  if (!coords || coords.length < 2) return null;
+  const first = coords[0];
+  const last = coords[coords.length - 1];
+  return `${coords.length}:${first[0].toFixed(4)},${first[1].toFixed(4)}:${last[0].toFixed(4)},${last[1].toFixed(4)}`;
+}
+
+/**
+ * Detects route polyline changes and provides a loading signal for related UI fields.
+ *
+ * When `navRouteCoordinates` changes significantly (different fingerprint),
+ * `isRouteTransitioning` becomes true. It clears when:
+ * - `destinationName` or `etaMinutes` change (the fields caught up), OR
+ * - A timeout expires (handles same-destination reroutes where text stays the same)
+ *
+ * @param navRouteCoordinates — Current route polyline from vehicle state
+ * @param destinationName — Current destination name from vehicle state
+ * @param etaMinutes — Current ETA in minutes from vehicle state
+ */
+export function useRouteTransition(
+  navRouteCoordinates: [number, number][] | undefined,
+  destinationName: string | undefined,
+  etaMinutes: number | undefined,
+): { isRouteTransitioning: boolean } {
+  const [isTransitioning, setIsTransitioning] = useState(false);
+
+  // Track previous fingerprints to detect changes
+  const prevRouteRef = useRef<string | null>(null);
+  const staleDestRef = useRef<string | undefined>(undefined);
+  const staleEtaRef = useRef<number | undefined>(undefined);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Detect route fingerprint changes
+  const currentFingerprint = routeFingerprint(navRouteCoordinates);
+
+  useEffect(() => {
+    // Skip initial mount — no transition on first render
+    if (prevRouteRef.current === null) {
+      prevRouteRef.current = currentFingerprint;
+      return;
+    }
+
+    if (currentFingerprint !== prevRouteRef.current) {
+      // Route changed — capture stale values and start transitioning
+      staleDestRef.current = destinationName;
+      staleEtaRef.current = etaMinutes;
+      setIsTransitioning(true);
+      prevRouteRef.current = currentFingerprint;
+
+      // Auto-clear after timeout (handles same-destination reroutes)
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        setIsTransitioning(false);
+      }, TRANSITION_TIMEOUT_MS);
+    }
+  }, [currentFingerprint, destinationName, etaMinutes]);
+
+  // Clear transition when destination or ETA actually update
+  useEffect(() => {
+    if (!isTransitioning) return;
+
+    const destChanged = destinationName !== staleDestRef.current;
+    const etaChanged = etaMinutes !== staleEtaRef.current;
+
+    if (destChanged || etaChanged) {
+      setIsTransitioning(false);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    }
+  }, [isTransitioning, destinationName, etaMinutes]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  return { isRouteTransitioning: isTransitioning };
+}


### PR DESCRIPTION
## Summary

- Adds gold-tinted shimmer skeleton loading state for **destination name**, **origin name**, and **ETA** that activates when the route polyline updates via WebSocket before associated text fields catch up
- New `Skeleton` UI primitive (`src/components/ui/Skeleton.tsx`) with subtle gold shimmer animation matching the dark theme
- New `useRouteTransition` hook that fingerprints `navRouteCoordinates` and detects significant changes, auto-clearing after 2s or when destination/ETA fields update
- Wired into `DrivingPeekContent`, `DrivingHalfContent`, `StatRow`, and `TripProgressBar` via optional `isRouteTransitioning` prop from `HomeScreen`

## How it works

1. `useRouteTransition` computes a fingerprint (length + first/last coordinate) of `navRouteCoordinates`
2. When the fingerprint changes, it captures the current `destinationName` and `etaMinutes` as "stale" values and sets `isRouteTransitioning = true`
3. Transitioning clears when **either**: destination/ETA change (fields caught up) **or** 2s timeout (same-destination reroute)
4. All driving UI components conditionally render `<Skeleton>` placeholders instead of text during transitions

## Test plan

- [x] Unit tests for `Skeleton` component (renders role, aria-label, shimmer child)
- [x] Unit tests for `useRouteTransition` hook (fingerprint detection, clearing on dest/ETA change, auto-clear timeout, no false positives)
- [x] Updated tests for `StatRow`, `TripProgressBar`, `DrivingPeekContent`, `DrivingHalfContent` verifying skeleton rendering during transitions
- [x] Existing tests pass unchanged (all new props are optional)
- [ ] CI typecheck + build

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)