### PR TITLE
Fix skeleton to clear on actual nav field arrival, not 2s timeout

### DIFF
--- a/__tests__/features/vehicles/hooks/use-route-transition.test.ts
+++ b/__tests__/features/vehicles/hooks/use-route-transition.test.ts
@@ -10,7 +10,7 @@ describe('useRouteTransition', () => {
 
   it('starts as not transitioning', () => {
     const coords: [number, number][] = [[0, 0], [1, 1]];
-    const { result } = renderHook(() => useRouteTransition(coords, 'Home', 10));
+    const { result } = renderHook(() => useRouteTransition(coords, 'Home', 10, []));
     expect(result.current.isRouteTransitioning).toBe(false);
   });
 
@@ -19,68 +19,145 @@ describe('useRouteTransition', () => {
     const route2: [number, number][] = [[0, 0], [2, 2], [3, 3]];
 
     const { result, rerender } = renderHook(
-      ({ coords, dest, eta }) => useRouteTransition(coords, dest, eta),
-      { initialProps: { coords: route1, dest: 'Home', eta: 10 } },
+      ({ coords, dest, eta, fields }) => useRouteTransition(coords, dest, eta, fields),
+      { initialProps: { coords: route1, dest: 'Home', eta: 10, fields: [] as string[] } },
     );
 
     expect(result.current.isRouteTransitioning).toBe(false);
 
     // Route changes — should start transitioning
-    rerender({ coords: route2, dest: 'Home', eta: 10 });
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: [] });
     expect(result.current.isRouteTransitioning).toBe(true);
   });
 
-  it('clears transition when destination name changes', () => {
+  it('clears transition when destination name changes (value comparison)', () => {
     const route1: [number, number][] = [[0, 0], [1, 1]];
     const route2: [number, number][] = [[0, 0], [2, 2], [3, 3]];
 
     const { result, rerender } = renderHook(
-      ({ coords, dest, eta }) => useRouteTransition(coords, dest, eta),
-      { initialProps: { coords: route1, dest: 'Home', eta: 10 } },
+      ({ coords, dest, eta, fields }) => useRouteTransition(coords, dest, eta, fields),
+      { initialProps: { coords: route1, dest: 'Home', eta: 10, fields: [] as string[] } },
     );
 
     // Route changes — transitioning starts
-    rerender({ coords: route2, dest: 'Home', eta: 10 });
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: [] });
     expect(result.current.isRouteTransitioning).toBe(true);
 
-    // Destination updates — transitioning clears
-    rerender({ coords: route2, dest: 'Office', eta: 10 });
+    // Destination value updates — transitioning clears
+    rerender({ coords: route2, dest: 'Office', eta: 10, fields: [] });
     expect(result.current.isRouteTransitioning).toBe(false);
   });
 
-  it('clears transition when ETA changes', () => {
+  it('clears transition when ETA changes (value comparison)', () => {
     const route1: [number, number][] = [[0, 0], [1, 1]];
     const route2: [number, number][] = [[0, 0], [2, 2], [3, 3]];
 
     const { result, rerender } = renderHook(
-      ({ coords, dest, eta }) => useRouteTransition(coords, dest, eta),
-      { initialProps: { coords: route1, dest: 'Home', eta: 10 } },
+      ({ coords, dest, eta, fields }) => useRouteTransition(coords, dest, eta, fields),
+      { initialProps: { coords: route1, dest: 'Home', eta: 10, fields: [] as string[] } },
     );
 
-    rerender({ coords: route2, dest: 'Home', eta: 10 });
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: [] });
     expect(result.current.isRouteTransitioning).toBe(true);
 
-    // ETA updates — transitioning clears
-    rerender({ coords: route2, dest: 'Home', eta: 15 });
+    // ETA value updates — transitioning clears
+    rerender({ coords: route2, dest: 'Home', eta: 15, fields: [] });
     expect(result.current.isRouteTransitioning).toBe(false);
   });
 
-  it('auto-clears after timeout', () => {
+  it('clears transition when lastUpdateFields includes destinationName', () => {
+    const route1: [number, number][] = [[0, 0], [1, 1]];
+    const route2: [number, number][] = [[0, 0], [2, 2], [3, 3]];
+
+    const { result, rerender } = renderHook(
+      ({ coords, dest, eta, fields }) => useRouteTransition(coords, dest, eta, fields),
+      { initialProps: { coords: route1, dest: 'Home', eta: 10, fields: [] as string[] } },
+    );
+
+    // Route changes — transitioning starts
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: ['navRouteCoordinates'] });
+    expect(result.current.isRouteTransitioning).toBe(true);
+
+    // First subsequent render — watchingRef activates (fields skipped)
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: ['speed'] });
+    expect(result.current.isRouteTransitioning).toBe(true);
+
+    // Second subsequent render — destinationName field arrives, clears skeleton
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: ['destinationName'] });
+    expect(result.current.isRouteTransitioning).toBe(false);
+  });
+
+  it('clears transition when lastUpdateFields includes etaMinutes', () => {
+    const route1: [number, number][] = [[0, 0], [1, 1]];
+    const route2: [number, number][] = [[0, 0], [2, 2], [3, 3]];
+
+    const { result, rerender } = renderHook(
+      ({ coords, dest, eta, fields }) => useRouteTransition(coords, dest, eta, fields),
+      { initialProps: { coords: route1, dest: 'Home', eta: 10, fields: [] as string[] } },
+    );
+
+    // Route changes
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: ['navRouteCoordinates'] });
+    expect(result.current.isRouteTransitioning).toBe(true);
+
+    // First subsequent render — watchingRef activates
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: ['heading'] });
+    expect(result.current.isRouteTransitioning).toBe(true);
+
+    // etaMinutes field arrives — clears skeleton
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: ['etaMinutes'] });
+    expect(result.current.isRouteTransitioning).toBe(false);
+  });
+
+  it('does NOT clear transition when lastUpdateFields contains only non-nav fields', () => {
     vi.useFakeTimers();
 
     const route1: [number, number][] = [[0, 0], [1, 1]];
     const route2: [number, number][] = [[0, 0], [2, 2], [3, 3]];
 
     const { result, rerender } = renderHook(
-      ({ coords, dest, eta }) => useRouteTransition(coords, dest, eta),
-      { initialProps: { coords: route1, dest: 'Home', eta: 10 } },
+      ({ coords, dest, eta, fields }) => useRouteTransition(coords, dest, eta, fields),
+      { initialProps: { coords: route1, dest: 'Home', eta: 10, fields: [] as string[] } },
     );
 
-    rerender({ coords: route2, dest: 'Home', eta: 10 });
+    // Route changes
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: [] });
     expect(result.current.isRouteTransitioning).toBe(true);
 
-    // Advance past the 2s timeout
+    // First subsequent render — watchingRef activates
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: ['speed'] });
+    expect(result.current.isRouteTransitioning).toBe(true);
+
+    // Non-nav fields — should NOT clear
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: ['speed', 'heading'] });
+    expect(result.current.isRouteTransitioning).toBe(true);
+
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: ['latitude', 'longitude'] });
+    expect(result.current.isRouteTransitioning).toBe(true);
+
+    vi.useRealTimers();
+  });
+
+  it('auto-clears after 10s failsafe timeout', () => {
+    vi.useFakeTimers();
+
+    const route1: [number, number][] = [[0, 0], [1, 1]];
+    const route2: [number, number][] = [[0, 0], [2, 2], [3, 3]];
+
+    const { result, rerender } = renderHook(
+      ({ coords, dest, eta, fields }) => useRouteTransition(coords, dest, eta, fields),
+      { initialProps: { coords: route1, dest: 'Home', eta: 10, fields: [] as string[] } },
+    );
+
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: [] });
+    expect(result.current.isRouteTransitioning).toBe(true);
+
+    // 2s should NOT clear (old behavior was 2s — that's gone now)
     act(() => { vi.advanceTimersByTime(2100); });
+    expect(result.current.isRouteTransitioning).toBe(true);
+
+    // 10s failsafe clears the skeleton
+    act(() => { vi.advanceTimersByTime(8000); });
     expect(result.current.isRouteTransitioning).toBe(false);
 
     vi.useRealTimers();
@@ -88,14 +165,14 @@ describe('useRouteTransition', () => {
 
   it('does not transition when route is undefined', () => {
     const { result, rerender } = renderHook(
-      ({ coords, dest, eta }) => useRouteTransition(coords, dest, eta),
-      { initialProps: { coords: undefined as [number, number][] | undefined, dest: 'Home', eta: 10 } },
+      ({ coords, dest, eta, fields }) => useRouteTransition(coords, dest, eta, fields),
+      { initialProps: { coords: undefined as [number, number][] | undefined, dest: 'Home', eta: 10, fields: [] as string[] } },
     );
 
     expect(result.current.isRouteTransitioning).toBe(false);
 
     // Still undefined — no transition
-    rerender({ coords: undefined, dest: 'Home', eta: 10 });
+    rerender({ coords: undefined, dest: 'Home', eta: 10, fields: [] });
     expect(result.current.isRouteTransitioning).toBe(false);
   });
 
@@ -103,17 +180,46 @@ describe('useRouteTransition', () => {
     const route: [number, number][] = [[0, 0], [1, 1]];
 
     const { result, rerender } = renderHook(
-      ({ coords, dest, eta }) => useRouteTransition(coords, dest, eta),
-      { initialProps: { coords: route, dest: 'Home', eta: 10 } },
+      ({ coords, dest, eta, fields }) => useRouteTransition(coords, dest, eta, fields),
+      { initialProps: { coords: route, dest: 'Home', eta: 10, fields: [] as string[] } },
     );
 
     // Same reference — no change
-    rerender({ coords: route, dest: 'Home', eta: 10 });
+    rerender({ coords: route, dest: 'Home', eta: 10, fields: [] });
     expect(result.current.isRouteTransitioning).toBe(false);
 
     // New array, same fingerprint — no change
     const routeCopy: [number, number][] = [[0, 0], [1, 1]];
-    rerender({ coords: routeCopy, dest: 'Home', eta: 10 });
+    rerender({ coords: routeCopy, dest: 'Home', eta: 10, fields: [] });
     expect(result.current.isRouteTransitioning).toBe(false);
+  });
+
+  it('cancels failsafe timeout when nav field arrives', () => {
+    vi.useFakeTimers();
+
+    const route1: [number, number][] = [[0, 0], [1, 1]];
+    const route2: [number, number][] = [[0, 0], [2, 2], [3, 3]];
+
+    const { result, rerender } = renderHook(
+      ({ coords, dest, eta, fields }) => useRouteTransition(coords, dest, eta, fields),
+      { initialProps: { coords: route1, dest: 'Home', eta: 10, fields: [] as string[] } },
+    );
+
+    // Route changes — start transitioning
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: [] });
+    expect(result.current.isRouteTransitioning).toBe(true);
+
+    // First subsequent render — watchingRef activates
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: ['speed'] });
+
+    // Nav field arrives — clears immediately
+    rerender({ coords: route2, dest: 'Home', eta: 10, fields: ['destinationName'] });
+    expect(result.current.isRouteTransitioning).toBe(false);
+
+    // Verify failsafe timeout was cancelled — advancing past 10s should not error
+    act(() => { vi.advanceTimersByTime(11_000); });
+    expect(result.current.isRouteTransitioning).toBe(false);
+
+    vi.useRealTimers();
   });
 });

--- a/__tests__/features/vehicles/hooks/use-vehicle-stream.test.ts
+++ b/__tests__/features/vehicles/hooks/use-vehicle-stream.test.ts
@@ -89,6 +89,11 @@ describe('useVehicleStream', () => {
     expect(() => result.current.reconnect()).not.toThrow();
   });
 
+  it('initialises lastUpdateFields as an empty Record', () => {
+    const { result } = renderHook(() => useVehicleStream(oneVehicle));
+    expect(result.current.lastUpdateFields).toEqual({});
+  });
+
   it('adds a new vehicle when the initial vehicles prop gains an entry', () => {
     // Start with one vehicle, then rerender with two
     const v1Only = [makeVehicle({ id: 'v1', name: 'Alpha' })];

--- a/src/features/vehicles/components/HomeScreen.tsx
+++ b/src/features/vehicles/components/HomeScreen.tsx
@@ -56,7 +56,7 @@ export function HomeScreen({ vehicles, drives, onSync, wsToken, userId }: HomeSc
 
   // Real-time telemetry via WebSocket — merges live updates into vehicle state.
   // vehicles is a Record<string, Vehicle>; no Map allocation on each update.
-  const { vehicles: liveVehicles } = useVehicleStream(vehicles, wsToken);
+  const { vehicles: liveVehicles, lastUpdateFields } = useVehicleStream(vehicles, wsToken);
 
   // Use live vehicle data if available, fall back to server-rendered data.
   const allVehicles = useMemo(() => {
@@ -74,10 +74,12 @@ export function HomeScreen({ vehicles, drives, onSync, wsToken, userId }: HomeSc
   );
 
   // Detect route polyline changes to show skeleton loading on stale text fields
+  const vehicleLastFields = lastUpdateFields[vehicle.id] ?? [];
   const { isRouteTransitioning } = useRouteTransition(
     vehicle.navRouteCoordinates,
     vehicle.destinationName,
     vehicle.etaMinutes,
+    vehicleLastFields,
   );
 
   // Derive driving status from gear — don't rely on the backend status field

--- a/src/features/vehicles/hooks/use-route-transition.ts
+++ b/src/features/vehicles/hooks/use-route-transition.ts
@@ -2,8 +2,11 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-/** Timeout (ms) before the transitioning state auto-clears. */
-const TRANSITION_TIMEOUT_MS = 2000;
+/** Failsafe timeout (ms) — clears skeleton if nav text fields never arrive. */
+const FAILSAFE_TIMEOUT_MS = 10_000;
+
+/** Nav text field names that signal the skeleton can be cleared. */
+const NAV_TEXT_FIELDS = ['destinationName', 'etaMinutes'];
 
 /**
  * Fingerprint a route polyline by its length, first, and last coordinate.
@@ -21,29 +24,36 @@ function routeFingerprint(coords: [number, number][] | undefined): string | null
  *
  * When `navRouteCoordinates` changes significantly (different fingerprint),
  * `isRouteTransitioning` becomes true. It clears when:
- * - `destinationName` or `etaMinutes` change (the fields caught up), OR
- * - A timeout expires (handles same-destination reroutes where text stays the same)
+ * - `lastUpdateFields` includes `destinationName` or `etaMinutes` (field-aware), OR
+ * - `destinationName` or `etaMinutes` VALUES change (same-message delivery fallback), OR
+ * - A 10s failsafe timeout expires (handles extreme edge cases)
  *
  * @param navRouteCoordinates — Current route polyline from vehicle state
  * @param destinationName — Current destination name from vehicle state
  * @param etaMinutes — Current ETA in minutes from vehicle state
+ * @param lastUpdateFields — Field names from the most recent WebSocket update
  */
 export function useRouteTransition(
   navRouteCoordinates: [number, number][] | undefined,
   destinationName: string | undefined,
   etaMinutes: number | undefined,
+  lastUpdateFields: string[],
 ): { isRouteTransitioning: boolean } {
   const [isTransitioning, setIsTransitioning] = useState(false);
 
-  // Track previous fingerprints to detect changes
+  // Track previous fingerprints and stale values for comparison
   const prevRouteRef = useRef<string | null>(null);
   const staleDestRef = useRef<string | undefined>(undefined);
   const staleEtaRef = useRef<number | undefined>(undefined);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Detect route fingerprint changes
+  // Flag to skip the first render's lastUpdateFields after a route change,
+  // since that render carries the route change itself, not the nav text update.
+  const watchingRef = useRef(false);
+
   const currentFingerprint = routeFingerprint(navRouteCoordinates);
 
+  // Detect route fingerprint changes — start transitioning
   useEffect(() => {
     // Skip initial mount — no transition on first render
     if (prevRouteRef.current === null) {
@@ -56,17 +66,43 @@ export function useRouteTransition(
       staleDestRef.current = destinationName;
       staleEtaRef.current = etaMinutes;
       setIsTransitioning(true);
+      watchingRef.current = false; // Don't check this render's fields
       prevRouteRef.current = currentFingerprint;
 
-      // Auto-clear after timeout (handles same-destination reroutes)
+      // Start failsafe timeout (10s) — clears skeleton even if nav text never arrives
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
       timeoutRef.current = setTimeout(() => {
         setIsTransitioning(false);
-      }, TRANSITION_TIMEOUT_MS);
+      }, FAILSAFE_TIMEOUT_MS);
     }
   }, [currentFingerprint, destinationName, etaMinutes]);
 
-  // Clear transition when destination or ETA actually update
+  // Watch for nav text fields in subsequent WebSocket updates
+  useEffect(() => {
+    if (!isTransitioning) {
+      watchingRef.current = false;
+      return;
+    }
+
+    // Skip the first render after route change (it carries the route update's fields)
+    if (!watchingRef.current) {
+      watchingRef.current = true;
+      return;
+    }
+
+    // Check if nav text fields arrived in this update
+    const hasNavText = lastUpdateFields.some((f) => NAV_TEXT_FIELDS.includes(f));
+    if (hasNavText) {
+      setIsTransitioning(false);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    }
+  }, [isTransitioning, lastUpdateFields]);
+
+  // Also clear on value changes (handles same-message delivery where
+  // nav text arrives in the same WebSocket message as coordinates)
   useEffect(() => {
     if (!isTransitioning) return;
 

--- a/src/features/vehicles/hooks/use-vehicle-stream.ts
+++ b/src/features/vehicles/hooks/use-vehicle-stream.ts
@@ -14,6 +14,8 @@ export interface UseVehicleStreamReturn {
   connectionStatus: ConnectionStatus;
   /** Manually trigger a reconnection attempt. */
   reconnect: () => void;
+  /** Field names from the most recent WebSocket update, keyed by vehicle ID. */
+  lastUpdateFields: Record<string, string[]>;
 }
 
 /** WebSocket URL from environment — empty disables WebSocket. */
@@ -45,12 +47,14 @@ export function useVehicleStream(
     return record;
   });
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('disconnected');
+  const [lastUpdateFields, setLastUpdateFields] = useState<Record<string, string[]>>({});
 
   const wsRef = useRef<VehicleWebSocket | null>(null);
 
   // Handle incoming vehicle update — merge partial fields into existing state.
   // Only returns a new reference when the vehicle data has actually changed,
   // preventing unnecessary re-renders from identity churn.
+  // Also tracks which fields arrived so consumers can react to field presence.
   const handleUpdate = useCallback((update: VehicleUpdate) => {
     setVehicles((prev) => {
       const existing = prev[update.vehicleId];
@@ -58,6 +62,10 @@ export function useVehicleStream(
       const updated = { ...existing, ...update.fields } as Vehicle;
       return { ...prev, [update.vehicleId]: updated };
     });
+    setLastUpdateFields((prev) => ({
+      ...prev,
+      [update.vehicleId]: Object.keys(update.fields),
+    }));
   }, []);
 
   // Connect/disconnect lifecycle
@@ -101,5 +109,6 @@ export function useVehicleStream(
     vehicles,
     connectionStatus,
     reconnect,
+    lastUpdateFields,
   };
 }


### PR DESCRIPTION
## Summary

- **Exposed `lastUpdateFields`** from `useVehicleStream` — tracks which field names arrived in the most recent WebSocket update per vehicle
- **Rewrote `useRouteTransition`** to accept `lastUpdateFields` and clear the skeleton only when `destinationName` or `etaMinutes` fields actually arrive (field-aware clearing)
- **Replaced the 2s unconditional timeout** with a 10s failsafe timeout that only fires if nav text fields never arrive
- **Preserved value-comparison clearing** as a fallback for same-message delivery (coordinates + nav text in one update)
- **Updated all tests** — removed 2s timeout expectation, added field-aware clearing tests, non-nav field rejection test, and failsafe timeout test

### The bug (from #226)

Skeleton auto-cleared after 2s, but `destinationName`/`etaMinutes` often hadn't arrived yet via WebSocket. User saw: skeleton → stale data → new data.

### The fix

The skeleton now stays visible until the WebSocket delivers an update containing `destinationName` or `etaMinutes`. A `watchingRef` flag ensures we skip the render that triggered the route change (it carries the route coordinates, not the nav text). A 10s failsafe handles edge cases where nav text never arrives.

Closes #227

## Test plan

- [ ] Verify skeleton stays visible when route changes and nav text hasn't arrived yet
- [ ] Verify skeleton clears immediately when `destinationName` or `etaMinutes` field arrives via WebSocket
- [ ] Verify skeleton does NOT clear when non-nav fields (speed, heading) arrive
- [ ] Verify skeleton clears after 10s failsafe if nav text never arrives
- [ ] Verify value-comparison clearing still works (same-message delivery)
- [ ] Run `npm test` — all unit tests pass
- [ ] Run `npm run typecheck` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)