### PR TITLE
#153 Add navRouteCoordinates column to Vehicle model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,6 +79,7 @@ model Vehicle {
   etaMinutes           Int?
   tripDistanceMiles    Float?
   tripDistanceRemaining Float?
+  navRouteCoordinates   Json?
   lastUpdated      DateTime      @default(now())
   createdAt        DateTime      @default(now())
   updatedAt        DateTime      @updatedAt

--- a/src/features/vehicles/api/vehicle-mappers.ts
+++ b/src/features/vehicles/api/vehicle-mappers.ts
@@ -131,6 +131,9 @@ export function mapPrismaVehicleToVehicle(prismaVehicle: PrismaVehicleWithStops)
   if (prismaVehicle.tripDistanceRemaining != null) {
     vehicle.tripDistanceRemaining = prismaVehicle.tripDistanceRemaining;
   }
+  if (prismaVehicle.navRouteCoordinates != null) {
+    vehicle.navRouteCoordinates = prismaVehicle.navRouteCoordinates as [number, number][];
+  }
   if (stops.length > 0) {
     vehicle.stops = stops;
   }


### PR DESCRIPTION
## Summary
- Adds `navRouteCoordinates Json?` column to the Vehicle Prisma model so the telemetry server can persist decoded route polyline coordinates to the database
- Maps the new Prisma field to the frontend `Vehicle` TypeScript type in `vehicle-mappers.ts`
- Enables users opening the app mid-drive to see the route polyline on initial page load (currently only available via WebSocket memory)

## Context
Companion PR to the telemetry server changes (tnando/my-robo-taxi-telemetry#153) which writes the decoded `navRouteCoordinates` JSON to this column on every RouteLine telemetry event.

## Test plan
- [ ] Run `npx prisma migrate dev` locally to verify migration generates correctly
- [ ] Verify `npx tsc --noEmit` passes with the new Prisma field mapped
- [ ] Confirm `navRouteCoordinates` appears on the Vehicle object returned by the API when the column has data
- [ ] Verify initial page load shows route polyline when vehicle has persisted nav route coordinates

🤖 Generated with [Claude Code](https://claude.com/claude-code)