### PR TITLE
Fix: add missing migration for navRouteCoordinates column

### DIFF
--- a/prisma/migrations/20260403000000_add_nav_route_coordinates/migration.sql
+++ b/prisma/migrations/20260403000000_add_nav_route_coordinates/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Vehicle" ADD COLUMN     "navRouteCoordinates" JSONB;


### PR DESCRIPTION
## Summary

- **Hotfix** — PR #229 added `navRouteCoordinates Json?` to the Prisma schema but did not include the database migration
- Prisma generates SQL with `SELECT ... "navRouteCoordinates" ...` but the column doesn't exist, causing a runtime error ("something went wrong")
- Adds the missing `ALTER TABLE "Vehicle" ADD COLUMN "navRouteCoordinates" JSONB` migration

## Test plan

- [x] Migration SQL is valid PostgreSQL
- [ ] CI passes
- [ ] Deploy applies migration → app recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)