### PR TITLE
MYR-41 Add chargeState + timeToFull columns to Vehicle

### DIFF
--- a/prisma/migrations/20260425195000_add_charge_state_time_to_full/migration.sql
+++ b/prisma/migrations/20260425195000_add_charge_state_time_to_full/migration.sql
@@ -1,0 +1,18 @@
+-- MYR-41: Add chargeState + timeToFull columns to Vehicle.
+--
+-- Closes the REST `/snapshot` DB-persistence gap for the two charge-atomic-group
+-- members wired live on WebSocket by MYR-40 (2026-04-22). Until this migration
+-- deploys, live `vehicle_update` WS frames carry both fields but the REST
+-- snapshot returns null because the columns don't exist.
+--
+-- Both columns are nullable (a vehicle that has never charged has no charge
+-- state to record). The Go server (telemetry repo) maps Tesla proto field 179
+-- DetailedChargeState -> chargeState (enum string) and proto field 43
+-- TimeToFullCharge -> timeToFull (double, hours).
+--
+-- Deploy ordering: this migration MUST run against production BEFORE the
+-- companion telemetry-server PR deploys with the new SELECT/UPDATE columns.
+-- See websocket-protocol.md §10 DV-03 + DV-04 for the contract context.
+
+ALTER TABLE "Vehicle" ADD COLUMN     "chargeState" TEXT,
+ADD COLUMN     "timeToFull" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,48 +45,50 @@ model Account {
 // ─── Vehicles ────────────────────────────────────────────────────────────────
 
 model Vehicle {
-  id               String        @id @default(cuid())
-  userId           String
-  teslaVehicleId   String?       @unique
-  vin              String?       @unique
-  name             String
-  model            String
-  year             Int
-  color            String
-  licensePlate     String
-  chargeLevel      Int           @default(0)
-  estimatedRange   Int           @default(0)
-  status           VehicleStatus @default(offline)
-  speed            Int           @default(0)
-  gearPosition     String?
-  heading          Int           @default(0)
-  locationName     String        @default("")
-  locationAddress  String        @default("")
-  latitude         Float         @default(0)
-  longitude        Float         @default(0)
-  interiorTemp     Int           @default(0)
-  exteriorTemp     Int           @default(0)
-  odometerMiles    Int           @default(0)
-  fsdMilesSinceReset Float       @default(0)
-  virtualKeyPaired Boolean       @default(false)
-  setupStatus      SetupStatus   @default(pending_pairing)
-  destinationName      String?
-  destinationAddress   String?
-  destinationLatitude  Float?
-  destinationLongitude Float?
-  originLatitude       Float?
-  originLongitude      Float?
-  etaMinutes           Int?
-  tripDistanceMiles    Float?
+  id                    String        @id @default(cuid())
+  userId                String
+  teslaVehicleId        String?       @unique
+  vin                   String?       @unique
+  name                  String
+  model                 String
+  year                  Int
+  color                 String
+  licensePlate          String
+  chargeLevel           Int           @default(0)
+  estimatedRange        Int           @default(0)
+  chargeState           String?
+  timeToFull            Float?
+  status                VehicleStatus @default(offline)
+  speed                 Int           @default(0)
+  gearPosition          String?
+  heading               Int           @default(0)
+  locationName          String        @default("")
+  locationAddress       String        @default("")
+  latitude              Float         @default(0)
+  longitude             Float         @default(0)
+  interiorTemp          Int           @default(0)
+  exteriorTemp          Int           @default(0)
+  odometerMiles         Int           @default(0)
+  fsdMilesSinceReset    Float         @default(0)
+  virtualKeyPaired      Boolean       @default(false)
+  setupStatus           SetupStatus   @default(pending_pairing)
+  destinationName       String?
+  destinationAddress    String?
+  destinationLatitude   Float?
+  destinationLongitude  Float?
+  originLatitude        Float?
+  originLongitude       Float?
+  etaMinutes            Int?
+  tripDistanceMiles     Float?
   tripDistanceRemaining Float?
   navRouteCoordinates   Json?
-  lastUpdated      DateTime      @default(now())
-  createdAt        DateTime      @default(now())
-  updatedAt        DateTime      @updatedAt
-  user             User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  drives           Drive[]
-  stops            TripStop[]
-  invites          Invite[]
+  lastUpdated           DateTime      @default(now())
+  createdAt             DateTime      @default(now())
+  updatedAt             DateTime      @updatedAt
+  user                  User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  drives                Drive[]
+  stops                 TripStop[]
+  invites               Invite[]
 
   @@index([userId])
 }
@@ -172,9 +174,9 @@ model Invite {
   vehicle      Vehicle          @relation(fields: [vehicleId], references: [id], onDelete: Cascade)
   sender       User             @relation("InviteSender", fields: [senderId], references: [id], onDelete: Cascade)
 
+  @@unique([vehicleId, email])
   @@index([senderId])
   @@index([vehicleId])
-  @@unique([vehicleId, email])
 }
 
 enum InviteStatus {
@@ -190,18 +192,18 @@ enum InvitePermission {
 // ─── Settings ────────────────────────────────────────────────────────────────
 
 model Settings {
-  id                    String   @id @default(cuid())
-  userId                String   @unique
-  teslaLinked           Boolean  @default(false)
-  teslaVehicleName      String?
-  virtualKeyPaired          Boolean   @default(false)
-  keyPairingDeferredAt      DateTime?
-  keyPairingReminderCount   Int       @default(0)
-  notifyDriveStarted        Boolean   @default(true)
-  notifyDriveCompleted  Boolean  @default(true)
-  notifyChargingComplete Boolean @default(true)
-  notifyViewerJoined    Boolean  @default(true)
-  createdAt             DateTime @default(now())
-  updatedAt             DateTime @updatedAt
-  user                  User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                      String    @id @default(cuid())
+  userId                  String    @unique
+  teslaLinked             Boolean   @default(false)
+  teslaVehicleName        String?
+  virtualKeyPaired        Boolean   @default(false)
+  keyPairingDeferredAt    DateTime?
+  keyPairingReminderCount Int       @default(0)
+  notifyDriveStarted      Boolean   @default(true)
+  notifyDriveCompleted    Boolean   @default(true)
+  notifyChargingComplete  Boolean   @default(true)
+  notifyViewerJoined      Boolean   @default(true)
+  createdAt               DateTime  @default(now())
+  updatedAt               DateTime  @updatedAt
+  user                    User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 }


### PR DESCRIPTION
## Summary

- Adds `chargeState String?` and `timeToFull Float?` columns to the `Vehicle` model in `prisma/schema.prisma`.
- Generates migration `20260425195000_add_charge_state_time_to_full` (`ALTER TABLE "Vehicle" ADD COLUMN ...`).
- Closes the REST `/snapshot` DB-persistence gap that [MYR-40](https://linear.app/myrobotaxi/issue/MYR-40) left open. Until this lands, live `vehicle_update` WS frames carry both fields but the cold-start `/snapshot` endpoint returns `null` because the columns don't exist.

## Background

Both columns are **nullable** — a vehicle that has never charged has no `chargeState` to record. The Go telemetry server maps Tesla proto field 179 (`DetailedChargeState`, enum string) → `chargeState` and proto field 43 (`TimeToFullCharge`, double, hours) → `timeToFull`. See `../my-robo-taxi-telemetry/docs/contracts/websocket-protocol.md` §10 DV-03 / DV-04 for the contract context.

## Deploy ordering (CRITICAL)

This Prisma migration **MUST** run against production **BEFORE** the companion telemetry-server PR ([tnando/my-robo-taxi-telemetry#MYR-41](https://github.com/tnando/my-robo-taxi-telemetry)) deploys. If the Go server deploys first, its `SELECT chargeState, timeToFull FROM "Vehicle"` will fail with `column does not exist`.

After this PR merges:
1. Run `npx prisma migrate deploy` against the prod Supabase URL (manual ops step).
2. Verify with `SELECT column_name FROM information_schema.columns WHERE table_name = 'Vehicle' AND column_name IN ('chargeState', 'timeToFull')` — should return both rows.
3. Mark the companion telemetry-server PR ready-for-review.

## Test plan

- [ ] `npx prisma format` accepts the schema (verified locally).
- [ ] CI green (Next.js E2E uses `prisma db push` so the new columns flow through automatically).
- [ ] Spot-check `prisma migrate diff` against the existing migration set produces no drift after merge.
- [ ] Post-deploy verification: query `information_schema.columns` to confirm both columns exist before signaling the Go PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)