### PR TITLE
MYR-59 Rename Vehicle.routeCoordinates -> Vehicle.driveTrailCoordinates

### DIFF
--- a/src/types/vehicle.ts
+++ b/src/types/vehicle.ts
@@ -65,9 +65,9 @@ export interface Vehicle {
   tripDistanceMiles?: number;
   tripDistanceRemaining?: number;
   stops?: TripStop[];
-  /** Navigation fields — populated via WebSocket real-time updates from Tesla RouteLine/nav data. */
-  routeCoordinates?: [number, number][];
-  /** Tesla's planned navigation polyline (route to destination). */
+  /** Accumulated GPS trail of an active drive ("where the car has been") — populated via WebSocket vehicle_update frames carrying `driveTrailCoordinates` from the server's per-drive route accumulator. Distinct from `navRouteCoordinates`; never conflate the two. */
+  driveTrailCoordinates?: [number, number][];
+  /** Tesla's planned navigation polyline ("where the car is going") — destination route, member of the navigation atomic group. */
   navRouteCoordinates?: [number, number][];
   destinationLatitude?: number;
   destinationLongitude?: number;


### PR DESCRIPTION
## Summary
- Renames `Vehicle.routeCoordinates` to `Vehicle.driveTrailCoordinates` in `src/types/vehicle.ts` to match the telemetry server's renamed wire field. Companion to [my-robo-taxi-telemetry#205](https://github.com/tnando/my-robo-taxi-telemetry/pull/205).
- The field carries the per-drive accumulated GPS trail emitted by the server's route accumulator and is semantically distinct from `navRouteCoordinates` (Tesla's planned navigation polyline). The doc-comment is updated to make this distinction explicit so future consumers don't conflate the two.
- Type-only change: zero consumers of `vehicle.routeCoordinates` exist today (verified via grep). The other `routeCoordinates` references in the repo are component prop names on different shapes (`DriveRouteMap routeCoordinates={drive.routePoints}`, `useRouteLayer routeCoordinates`, etc.) and are intentionally left alone.

## Coordination
Merge order: telemetry PR #205 first (server starts emitting the renamed wire key), then this PR. Because the type field has no consumer, there is no user-visible behavior change in this PR alone.

## Test plan
- [x] No `vehicle.routeCoordinates` accesses anywhere in the repo
- [ ] `pnpm typecheck` (or equivalent) passes
- [ ] After server PR merges and deploys: verify a future drive-trail consumer can read `vehicle.driveTrailCoordinates` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)