### PR TITLE
MYR-73 (Phase 1/Prisma) Add vehicle_deleted NOTIFY trigger

### DIFF
--- a/prisma/migrations/20260509164715_vehicle_deleted_notify_trigger/migration.sql
+++ b/prisma/migrations/20260509164715_vehicle_deleted_notify_trigger/migration.sql
@@ -1,0 +1,49 @@
+-- MYR-73: NOTIFY trigger for Vehicle DELETE so the Go telemetry server
+-- can react within seconds (no polling fallback).
+--
+-- Implements the §3.5 cleanup contract in
+-- docs/contracts/data-lifecycle.md (telemetry repo): when the Next.js
+-- FR-10.1 deletion transaction commits, the trigger fires a
+-- pg_notify('vehicle_deleted', ...) event carrying the (vehicleId,
+-- userId, vin) tuple. The Go side LISTENs on a dedicated long-lived
+-- connection and publishes a domain event that closes:
+--   1. WebSocket clients subscribed to the vehicle (close code 4002).
+--   2. The active inbound Tesla mTLS stream for that VIN (registry
+--      lookup is VIN-keyed, hence the VIN payload field).
+--   3. The JWT user-existence cache entry for the owning user.
+--
+-- Operator notes:
+--   * `vin` may be NULL on early-setup vehicles (the Vehicle row exists
+--     before pairing completes). The Go side tolerates a null VIN: only
+--     the WebSocket cleanup path runs in that case (no mTLS stream
+--     can exist for an un-paired vehicle).
+--   * pg_notify payloads are capped at 8000 bytes by Postgres. The
+--     three-field JSON payload here is well under the limit.
+--   * Triggers do not round-trip through `prisma db pull`. If the
+--     database is rebuilt without replaying migrations the function
+--     and trigger MUST be re-created from this file.
+--   * The function name `notify_vehicle_deleted` and the trigger name
+--     `notify_vehicle_deleted_trigger` are stable identifiers; do not
+--     rename without updating the telemetry-repo LISTEN code.
+--   * Channel name is `vehicle_deleted` (snake_case). The Go listener
+--     in internal/store/notify_listener.go must use the same name.
+
+CREATE OR REPLACE FUNCTION notify_vehicle_deleted()
+RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM pg_notify(
+        'vehicle_deleted',
+        json_build_object(
+            'vehicleId', OLD."id",
+            'userId', OLD."userId",
+            'vin', OLD."vin"
+        )::text
+    );
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER notify_vehicle_deleted_trigger
+    AFTER DELETE ON "Vehicle"
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_vehicle_deleted();


### PR DESCRIPTION
## Summary

Adds a Postgres trigger on `Vehicle DELETE` that emits a `pg_notify('vehicle_deleted', ...)` event carrying the `(vehicleId, userId, vin)` tuple. This is the source of truth the Go telemetry server's `LISTEN` goroutine consumes to close client WebSocket sessions, unsubscribe Tesla mTLS streams, and invalidate the JWT user-existence cache after the Next.js FR-10.1 deletion transaction commits.

Implements the wakeup half of `docs/contracts/data-lifecycle.md` §3.5 (in the telemetry repo) — no polling fallback per the issue spec.

## Why a trigger and not application code

The Next.js layer already runs the FR-10.1 deletion in a Prisma `$transaction` (MYR-72). A trigger is the only way to guarantee the notification fires *after* the transaction commits — application code added to the deletion handler runs *before* commit, would leak the notification to consumers if the transaction later rolled back, and would silently miss any future deletion path that doesn't go through the same handler. The trigger fires for any DELETE on `Vehicle`, regardless of caller.

## Payload shape

```json
{ "vehicleId": "<cuid>", "userId": "<cuid>", "vin": "5YJ3..." | null }
```

`vin` is intentionally included even though the registry it indexes (the Tesla mTLS connection map in `internal/telemetry/`) is VIN-keyed — including it in the payload avoids a post-DELETE lookup that could not succeed (the row is gone). `vin` is null on early-setup vehicles that haven't paired yet; the Go consumer tolerates null (no mTLS stream can exist for an un-paired vehicle, so only the WS cleanup runs).

## Cross-repo

The Go consumer lands in the sibling repo PR: `tnando/my-robo-taxi-telemetry` MYR-73 (Phase 2/Go). Both PRs target the same Linear issue MYR-73; this repo's PR is intentionally tiny and merge-first because the Go side requires this trigger before its integration tests can pass.

## Smoke test

- `npx prisma migrate deploy` applied cleanly against staging.
- Verified function and trigger are registered in `pg_proc` and `pg_trigger`.
- Function body inspected via `pg_get_functiondef` — payload format matches the spec.

## Test plan

- [x] Migration applies cleanly to a fresh database
- [x] Migration applies cleanly idempotently against a database that already has Vehicle rows
- [x] `notify_vehicle_deleted` function and `notify_vehicle_deleted_trigger` trigger are present after migration
- [x] Function body uses `json_build_object` over OLD.* (correct trigger-context column references)
- [ ] End-to-end NOTIFY round-trip is exercised by the testcontainers integration test in the Phase 2 Go PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)