### PR TITLE
MYR-63 (Phase 1/TS) Encrypt Vehicle GPS columns + Prisma dual-write migration

### DIFF
--- a/__tests__/lib/vehicle-gps-encryption.test.ts
+++ b/__tests__/lib/vehicle-gps-encryption.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for `src/lib/vehicle-gps-encryption.ts` — dual-write /
+ * dual-read helpers for the encrypted Vehicle GPS shadow columns
+ * (MYR-63 Phase 1).
+ */
+
+import { Buffer } from 'node:buffer';
+
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+
+import { __resetEncryptor } from '@/lib/account-encryption';
+import { KEY_LEN, newEncryptor, loadKeySetFromEnv } from '@/lib/cryptox';
+import {
+  buildEncryptedVehicleGPSWrite,
+  readVehicleGPS,
+  type VehicleGPSFields,
+} from '@/lib/vehicle-gps-encryption';
+
+const TEST_KEY_B64 = Buffer.alloc(KEY_LEN, 0x33).toString('base64');
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  process.env.ENCRYPTION_KEY = TEST_KEY_B64;
+  __resetEncryptor();
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  delete process.env.ENCRYPTION_KEY;
+  __resetEncryptor();
+  warnSpy.mockRestore();
+});
+
+function encryptForTest(plaintext: string): string {
+  const ks = loadKeySetFromEnv();
+  return newEncryptor(ks).encryptString(plaintext);
+}
+
+describe('buildEncryptedVehicleGPSWrite', () => {
+  it('encrypts both halves of a complete pair', () => {
+    const out = buildEncryptedVehicleGPSWrite({
+      latitude: 37.7749,
+      longitude: -122.4194,
+    });
+    expect(out.latitudeEnc).toBeTruthy();
+    expect(out.longitudeEnc).toBeTruthy();
+    expect(out.latitudeEnc).not.toEqual(out.longitudeEnc);
+  });
+
+  it('round-trips through the encryptor lossless on doubles', () => {
+    const out = buildEncryptedVehicleGPSWrite({
+      latitude: 37.77491234567,
+      longitude: -122.41947654321,
+    });
+    const ks = loadKeySetFromEnv();
+    const enc = newEncryptor(ks);
+    expect(Number(enc.decryptString(out.latitudeEnc!))).toBe(37.77491234567);
+    expect(Number(enc.decryptString(out.longitudeEnc!))).toBe(-122.41947654321);
+  });
+
+  it('clears both shadows on null pair', () => {
+    const out = buildEncryptedVehicleGPSWrite({
+      destinationLatitude: null,
+      destinationLongitude: null,
+    });
+    expect(out.destinationLatitudeEnc).toBeNull();
+    expect(out.destinationLongitudeEnc).toBeNull();
+  });
+
+  it('leaves shadows untouched on undefined pair', () => {
+    const out = buildEncryptedVehicleGPSWrite({});
+    expect(out.latitudeEnc).toBeUndefined();
+    expect(out.longitudeEnc).toBeUndefined();
+    expect(out.destinationLatitudeEnc).toBeUndefined();
+    expect(out.originLatitudeEnc).toBeUndefined();
+  });
+
+  it('rejects half-pair input — leaves shadow untouched + warns', () => {
+    const out = buildEncryptedVehicleGPSWrite({
+      latitude: 37.7749,
+      // longitude omitted
+    });
+    expect(out.latitudeEnc).toBeUndefined();
+    expect(out.longitudeEnc).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('half-pair input for (latitude, longitude)'),
+    );
+  });
+
+  it('handles all three pairs independently', () => {
+    const out = buildEncryptedVehicleGPSWrite({
+      latitude: 1,
+      longitude: 2,
+      destinationLatitude: 3,
+      destinationLongitude: 4,
+      originLatitude: 5,
+      originLongitude: 6,
+    });
+    expect(out.latitudeEnc).toBeTruthy();
+    expect(out.longitudeEnc).toBeTruthy();
+    expect(out.destinationLatitudeEnc).toBeTruthy();
+    expect(out.destinationLongitudeEnc).toBeTruthy();
+    expect(out.originLatitudeEnc).toBeTruthy();
+    expect(out.originLongitudeEnc).toBeTruthy();
+  });
+});
+
+describe('readVehicleGPS', () => {
+  it('prefers *Enc when both halves of a pair are populated', () => {
+    const row: VehicleGPSFields = {
+      latitude: 0,
+      longitude: 0,
+      latitudeEnc: encryptForTest('37.7749'),
+      longitudeEnc: encryptForTest('-122.4194'),
+    };
+    const out = readVehicleGPS(row);
+    expect(out.latitude).toBe(37.7749);
+    expect(out.longitude).toBe(-122.4194);
+  });
+
+  it('falls back to plaintext when *Enc is NULL on both halves', () => {
+    const row: VehicleGPSFields = {
+      latitude: 1.23,
+      longitude: 4.56,
+      latitudeEnc: null,
+      longitudeEnc: null,
+    };
+    const out = readVehicleGPS(row);
+    expect(out.latitude).toBe(1.23);
+    expect(out.longitude).toBe(4.56);
+  });
+
+  it('treats half-pair *Enc (one populated, one NULL) as null + warns', () => {
+    const row: VehicleGPSFields = {
+      latitude: 1,
+      longitude: 2,
+      latitudeEnc: encryptForTest('37.7749'),
+      longitudeEnc: null,
+    };
+    const out = readVehicleGPS(row);
+    expect(out.latitude).toBeNull();
+    expect(out.longitude).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('half-pair *Enc detected'),
+    );
+  });
+
+  it('returns null pairs when both plaintext and *Enc are null/undefined', () => {
+    const row: VehicleGPSFields = {};
+    const out = readVehicleGPS(row);
+    expect(out.latitude).toBeNull();
+    expect(out.longitude).toBeNull();
+    expect(out.destinationLatitude).toBeNull();
+    expect(out.destinationLongitude).toBeNull();
+    expect(out.originLatitude).toBeNull();
+    expect(out.originLongitude).toBeNull();
+  });
+
+  it('reads destination + origin pairs independently of main pair', () => {
+    const row: VehicleGPSFields = {
+      latitudeEnc: encryptForTest('1'),
+      longitudeEnc: encryptForTest('2'),
+      destinationLatitude: 30,
+      destinationLongitude: 40,
+      destinationLatitudeEnc: null,
+      destinationLongitudeEnc: null,
+      originLatitudeEnc: encryptForTest('500'),
+      originLongitudeEnc: encryptForTest('600'),
+    };
+    const out = readVehicleGPS(row);
+    expect(out.latitude).toBe(1);
+    expect(out.longitude).toBe(2);
+    expect(out.destinationLatitude).toBe(30); // plaintext fallback
+    expect(out.destinationLongitude).toBe(40);
+    expect(out.originLatitude).toBe(500);
+    expect(out.originLongitude).toBe(600);
+  });
+
+  it('round-trips a Float written by buildEncryptedVehicleGPSWrite', () => {
+    const w = buildEncryptedVehicleGPSWrite({
+      latitude: 37.77491234567,
+      longitude: -122.41947654321,
+    });
+    const row: VehicleGPSFields = {
+      latitude: 37.77491234567,
+      longitude: -122.41947654321,
+      latitudeEnc: w.latitudeEnc,
+      longitudeEnc: w.longitudeEnc,
+    };
+    const out = readVehicleGPS(row);
+    expect(out.latitude).toBe(37.77491234567);
+    expect(out.longitude).toBe(-122.41947654321);
+  });
+});

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,5 +1,17 @@
 /**
  * Vitest global test setup.
  * Extends expect with jest-dom matchers for DOM assertions.
+ *
+ * Sets a deterministic ENCRYPTION_KEY so any test that exercises code
+ * paths through `@/lib/cryptox` or the dual-write helpers in
+ * `@/lib/account-encryption` / `@/lib/vehicle-gps-encryption` works
+ * without each test having to stub the env. Tests that mutate the key
+ * in beforeEach still take precedence — this is the default.
  */
+import { Buffer } from 'node:buffer';
+
 import '@testing-library/jest-dom/vitest';
+
+if (!process.env.ENCRYPTION_KEY) {
+  process.env.ENCRYPTION_KEY = Buffer.alloc(32, 0x11).toString('base64');
+}

--- a/prisma/migrations/20260509175411_add_vehicle_gps_enc_columns/migration.sql
+++ b/prisma/migrations/20260509175411_add_vehicle_gps_enc_columns/migration.sql
@@ -1,0 +1,33 @@
+-- MYR-63 Phase 1 — encrypted shadows for Vehicle GPS columns.
+--
+-- Adds six nullable TEXT columns to Vehicle for the dual-write rollout
+-- of P1-classified GPS coordinates per data-classification.md §1.3 and
+-- NFR-3.23. Writes go to BOTH the plaintext Float column AND the
+-- matching *Enc TEXT column; reads prefer *Enc with plaintext fallback.
+-- The plaintext Float columns will be dropped in a separate
+-- post-rollout migration once the backfill completes.
+--
+-- Atomic-pair semantics (vehicle-state-schema.md §3.3 GPS predicates):
+--   latitude/longitude, destinationLatitude/destinationLongitude, and
+--   originLatitude/originLongitude must be written + read as pairs.
+--   Half-NULL reads (one half present, the other NULL) are treated as
+--   NULL by the helper layer — never silently passed through.
+--
+-- Float→string conversion uses `String(x)` which round-trips losslessly
+-- through `Number(s)` for IEEE-754 doubles, keeping precision identical
+-- across the dual-write window.
+--
+-- Ciphertext format owned by lib/cryptox (TS) and internal/cryptox (Go):
+--   [1B version=0x01][12B nonce][N B ct + 16B tag], base64(StdEncoding).
+--
+-- Additive only — no rewrite of existing rows. Phase 2 in the
+-- my-robo-taxi-telemetry repo wires the Go writer/reader through the
+-- field mapper + repo using the same dual-write contract.
+
+ALTER TABLE "Vehicle"
+  ADD COLUMN "latitudeEnc"             TEXT,
+  ADD COLUMN "longitudeEnc"            TEXT,
+  ADD COLUMN "destinationLatitudeEnc"  TEXT,
+  ADD COLUMN "destinationLongitudeEnc" TEXT,
+  ADD COLUMN "originLatitudeEnc"       TEXT,
+  ADD COLUMN "originLongitudeEnc"      TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,11 @@ model Vehicle {
   locationAddress       String        @default("")
   latitude              Float         @default(0)
   longitude             Float         @default(0)
+  // MYR-63 Phase 1 — encrypted shadow columns (P1 per data-classification.md §1.3,
+  // NFR-3.23). Dual-write window: writes go to BOTH plaintext Float and *Enc TEXT;
+  // reads prefer *Enc with plaintext fallback. See src/lib/vehicle-gps-encryption.ts.
+  latitudeEnc             String?
+  longitudeEnc            String?
   interiorTemp          Int           @default(0)
   exteriorTemp          Int           @default(0)
   odometerMiles         Int           @default(0)
@@ -85,8 +90,12 @@ model Vehicle {
   destinationAddress    String?
   destinationLatitude   Float?
   destinationLongitude  Float?
+  destinationLatitudeEnc  String?
+  destinationLongitudeEnc String?
   originLatitude        Float?
   originLongitude       Float?
+  originLatitudeEnc       String?
+  originLongitudeEnc      String?
   etaMinutes            Int?
   tripDistanceMiles     Float?
   tripDistanceRemaining Float?

--- a/src/features/vehicles/api/sync.ts
+++ b/src/features/vehicles/api/sync.ts
@@ -1,6 +1,7 @@
 import { detectAndRecordDrive } from '@/lib/drive-detection';
 import { prisma } from '@/lib/prisma';
 import { getTeslaAccessToken } from '@/lib/tesla';
+import { buildEncryptedVehicleGPSWrite } from '@/lib/vehicle-gps-encryption';
 import {
   listVehicles as teslaListVehicles,
   getVehicleData,
@@ -168,14 +169,23 @@ export async function syncVehiclesFromTesla(userId: string): Promise<number> {
       }
 
       if (hasValidCoords) {
-        updateData.latitude = upsertData.latitude;
-        updateData.longitude = upsertData.longitude;
+        Object.assign(
+          updateData,
+          buildEncryptedVehicleGPSWrite({
+            latitude: upsertData.latitude,
+            longitude: upsertData.longitude,
+          }),
+        );
       }
 
       const vehicle = await prisma.vehicle.upsert({
         where: { teslaVehicleId },
         create: {
           ...upsertData,
+          ...buildEncryptedVehicleGPSWrite({
+            latitude: upsertData.latitude,
+            longitude: upsertData.longitude,
+          }),
           userId,
           color: '',
           licensePlate: '',

--- a/src/features/vehicles/api/sync.ts
+++ b/src/features/vehicles/api/sync.ts
@@ -169,6 +169,8 @@ export async function syncVehiclesFromTesla(userId: string): Promise<number> {
       }
 
       if (hasValidCoords) {
+        updateData.latitude = upsertData.latitude;
+        updateData.longitude = upsertData.longitude;
         Object.assign(
           updateData,
           buildEncryptedVehicleGPSWrite({

--- a/src/features/vehicles/api/vehicle-mappers.ts
+++ b/src/features/vehicles/api/vehicle-mappers.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client';
 
+import { readVehicleGPS } from '@/lib/vehicle-gps-encryption';
 import { VALID_GEARS } from '@/types/vehicle';
 import type { Vehicle, TripStop, VehicleStatus, GearPosition, SetupStatus } from '@/types/vehicle';
 
@@ -76,6 +77,8 @@ export function mapPrismaVehicleToVehicle(prismaVehicle: PrismaVehicleWithStops)
     type: stop.type,
   }));
 
+  const gps = readVehicleGPS(prismaVehicle);
+
   const vehicle: Vehicle = {
     id: prismaVehicle.id,
     vin: prismaVehicle.vin ?? undefined,
@@ -92,8 +95,8 @@ export function mapPrismaVehicleToVehicle(prismaVehicle: PrismaVehicleWithStops)
     heading: prismaVehicle.heading,
     locationName: prismaVehicle.locationName,
     locationAddress: prismaVehicle.locationAddress,
-    latitude: prismaVehicle.latitude,
-    longitude: prismaVehicle.longitude,
+    latitude: gps.latitude ?? 0,
+    longitude: gps.longitude ?? 0,
     interiorTemp: prismaVehicle.interiorTemp,
     exteriorTemp: prismaVehicle.exteriorTemp,
     lastUpdated: formatRelativeTime(prismaVehicle.lastUpdated),
@@ -110,17 +113,17 @@ export function mapPrismaVehicleToVehicle(prismaVehicle: PrismaVehicleWithStops)
   if (prismaVehicle.destinationAddress) {
     vehicle.destinationAddress = prismaVehicle.destinationAddress;
   }
-  if (prismaVehicle.destinationLatitude != null) {
-    vehicle.destinationLatitude = prismaVehicle.destinationLatitude;
+  if (gps.destinationLatitude != null) {
+    vehicle.destinationLatitude = gps.destinationLatitude;
   }
-  if (prismaVehicle.destinationLongitude != null) {
-    vehicle.destinationLongitude = prismaVehicle.destinationLongitude;
+  if (gps.destinationLongitude != null) {
+    vehicle.destinationLongitude = gps.destinationLongitude;
   }
-  if (prismaVehicle.originLatitude != null) {
-    vehicle.originLatitude = prismaVehicle.originLatitude;
+  if (gps.originLatitude != null) {
+    vehicle.originLatitude = gps.originLatitude;
   }
-  if (prismaVehicle.originLongitude != null) {
-    vehicle.originLongitude = prismaVehicle.originLongitude;
+  if (gps.originLongitude != null) {
+    vehicle.originLongitude = gps.originLongitude;
   }
   if (prismaVehicle.etaMinutes != null) {
     vehicle.etaMinutes = prismaVehicle.etaMinutes;

--- a/src/lib/vehicle-gps-encryption.ts
+++ b/src/lib/vehicle-gps-encryption.ts
@@ -1,0 +1,219 @@
+/**
+ * Vehicle-GPS encryption helpers (MYR-63 Phase 1 — TS side).
+ *
+ * Centralises the dual-write/dual-read pattern for the encrypted shadow
+ * columns added to `Vehicle` (`latitudeEnc`, `longitudeEnc`,
+ * `destinationLatitudeEnc`, `destinationLongitudeEnc`,
+ * `originLatitudeEnc`, `originLongitudeEnc`) per data-classification.md
+ * §1.3 and NFR-3.23. Call sites should never reach past these helpers
+ * to read/write the columns directly.
+ *
+ * Atomic-pair semantics: latitude and longitude are persisted as separate
+ * columns but consumed as a synchronized pair (vehicle-state-schema.md
+ * §3.3 GPS predicates). If an `*Enc` half is non-NULL while its mate is
+ * NULL the row is corrupt — readVehicleGPS treats the entire pair as
+ * absent rather than returning a half-pair.
+ *
+ * Float ↔ string conversion uses `String(x)` / `Number(s)` which is
+ * lossless for finite IEEE-754 doubles.
+ *
+ * Rollout phases mirror MYR-62 (account tokens):
+ *   1. Dual-write (this PR)
+ *   2. Backfill — Phase 2 of MYR-63 (Go-side)
+ *   3. Read-flip — separate post-rollout issue
+ *   4. Drop plaintext columns — separate post-rollout issue
+ */
+
+import { getEncryptor } from '@/lib/account-encryption';
+
+type Pair = 'latitude' | 'destinationLatitude' | 'originLatitude';
+type LatField = Pair;
+type LngField =
+  | 'longitude'
+  | 'destinationLongitude'
+  | 'originLongitude';
+
+const PAIRS: ReadonlyArray<{ lat: LatField; lng: LngField }> = [
+  { lat: 'latitude', lng: 'longitude' },
+  { lat: 'destinationLatitude', lng: 'destinationLongitude' },
+  { lat: 'originLatitude', lng: 'originLongitude' },
+];
+
+/**
+ * Subset of a Vehicle row used by readers/writers. Each pair has a
+ * Float plaintext column (`latitude`) and a TEXT encrypted shadow
+ * (`latitudeEnc`). `latitude` and `longitude` are non-nullable on the
+ * schema (default 0); the destination/origin pairs are nullable.
+ */
+export interface VehicleGPSFields {
+  latitude?: number | null;
+  longitude?: number | null;
+  destinationLatitude?: number | null;
+  destinationLongitude?: number | null;
+  originLatitude?: number | null;
+  originLongitude?: number | null;
+  latitudeEnc?: string | null;
+  longitudeEnc?: string | null;
+  destinationLatitudeEnc?: string | null;
+  destinationLongitudeEnc?: string | null;
+  originLatitudeEnc?: string | null;
+  originLongitudeEnc?: string | null;
+}
+
+function encOf(v: number | null | undefined): string | null | undefined {
+  // `undefined` → leave column untouched (Prisma drops undefined).
+  // `null`      → explicitly clear shadow column.
+  // number      → encrypt the lossless string form.
+  if (v === undefined) return undefined;
+  if (v === null) return null;
+  return getEncryptor().encryptString(String(v));
+}
+
+function decOf(s: string | null | undefined): number | null {
+  if (!s) return null;
+  const plain = getEncryptor().decryptString(s);
+  if (plain === '') return null;
+  const n = Number(plain);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Resolve a single `(lat, lng)` pair, preferring the encrypted shadow
+ * columns and falling back to the Float plaintext for legacy rows.
+ *
+ * Returns `null` for the whole pair when either half is corrupt
+ * (mismatched NULL state on the `*Enc` columns) — half-pair reads must
+ * not leak through to consumers.
+ */
+function readPair(
+  row: VehicleGPSFields,
+  lat: LatField,
+  lng: LngField,
+): { lat: number | null; lng: number | null } {
+  const latEncCol = `${lat}Enc` as keyof VehicleGPSFields;
+  const lngEncCol = `${lng}Enc` as keyof VehicleGPSFields;
+  const latEncRaw = row[latEncCol] as string | null | undefined;
+  const lngEncRaw = row[lngEncCol] as string | null | undefined;
+
+  const latEncPresent = latEncRaw != null && latEncRaw !== '';
+  const lngEncPresent = lngEncRaw != null && lngEncRaw !== '';
+
+  if (latEncPresent !== lngEncPresent) {
+    // Half-pair encrypted write — corrupt. Treat as absent.
+    console.warn(
+      `[vehicle-gps-encryption] half-pair *Enc detected for (${lat}, ${lng}); reading as null`,
+    );
+    return { lat: null, lng: null };
+  }
+
+  if (latEncPresent && lngEncPresent) {
+    return { lat: decOf(latEncRaw), lng: decOf(lngEncRaw) };
+  }
+
+  // Fallback to plaintext.
+  const latPlain = (row[lat] as number | null | undefined) ?? null;
+  const lngPlain = (row[lng] as number | null | undefined) ?? null;
+  return { lat: latPlain, lng: lngPlain };
+}
+
+/**
+ * Read all three GPS pairs from a Vehicle row, applying dual-read
+ * fallback and atomic-pair integrity. Suitable for vehicle-mappers
+ * and any other code that surfaces GPS to clients.
+ */
+export function readVehicleGPS(row: VehicleGPSFields): {
+  latitude: number | null;
+  longitude: number | null;
+  destinationLatitude: number | null;
+  destinationLongitude: number | null;
+  originLatitude: number | null;
+  originLongitude: number | null;
+} {
+  const main = readPair(row, 'latitude', 'longitude');
+  const dest = readPair(row, 'destinationLatitude', 'destinationLongitude');
+  const orig = readPair(row, 'originLatitude', 'originLongitude');
+  return {
+    latitude: main.lat,
+    longitude: main.lng,
+    destinationLatitude: dest.lat,
+    destinationLongitude: dest.lng,
+    originLatitude: orig.lat,
+    originLongitude: orig.lng,
+  };
+}
+
+type GPSWriteInput = Pick<
+  VehicleGPSFields,
+  | 'latitude'
+  | 'longitude'
+  | 'destinationLatitude'
+  | 'destinationLongitude'
+  | 'originLatitude'
+  | 'originLongitude'
+>;
+
+export interface GPSEncShadowPayload {
+  latitudeEnc?: string | null;
+  longitudeEnc?: string | null;
+  destinationLatitudeEnc?: string | null;
+  destinationLongitudeEnc?: string | null;
+  originLatitudeEnc?: string | null;
+  originLongitudeEnc?: string | null;
+}
+
+/**
+ * Build the encrypted-shadow payload for a Vehicle create/update/upsert.
+ * Returns only the `*Enc` columns; callers continue to write the
+ * plaintext columns from their own data via spread (so this helper
+ * doesn't have to recreate Prisma's nullability typing for each
+ * plaintext field). Spread the result alongside the plaintext payload.
+ *
+ * Atomic-pair guarantee: if a caller passes only one half of a pair
+ * (e.g., `latitude` without `longitude`), neither shadow column is
+ * touched and a warning is logged — half-pair encrypted writes are
+ * the same corruption mode `readVehicleGPS` rejects on read.
+ *
+ * `undefined` for any field means "don't touch the shadow column";
+ * `null` means "clear the shadow column". A plaintext clear (set
+ * `latitude: null` on a nullable column) goes via the caller's main
+ * payload as before.
+ */
+export function buildEncryptedVehicleGPSWrite(
+  input: GPSWriteInput,
+): GPSEncShadowPayload {
+  const out: GPSEncShadowPayload = {};
+
+  for (const { lat, lng } of PAIRS) {
+    const latVal = input[lat];
+    const lngVal = input[lng];
+
+    const latProvided = latVal !== undefined;
+    const lngProvided = lngVal !== undefined;
+
+    if (!latProvided && !lngProvided) continue;
+
+    if (latProvided !== lngProvided) {
+      console.warn(
+        `[vehicle-gps-encryption] half-pair input for (${lat}, ${lng}); shadow columns left untouched`,
+      );
+      continue;
+    }
+
+    const latEncCol = `${lat}Enc` as keyof GPSEncShadowPayload;
+    const lngEncCol = `${lng}Enc` as keyof GPSEncShadowPayload;
+
+    if (latVal === null || lngVal === null) {
+      // Clear both shadows. (If only one half is null we treat the
+      // pair as a clear — a mixed null/number pair would violate
+      // atomic-pair semantics and is rejected at read time anyway.)
+      (out as Record<string, unknown>)[latEncCol] = null;
+      (out as Record<string, unknown>)[lngEncCol] = null;
+      continue;
+    }
+
+    (out as Record<string, unknown>)[latEncCol] = encOf(latVal);
+    (out as Record<string, unknown>)[lngEncCol] = encOf(lngVal);
+  }
+
+  return out;
+}

--- a/src/lib/vehicle-gps-encryption.ts
+++ b/src/lib/vehicle-gps-encryption.ts
@@ -203,9 +203,14 @@ export function buildEncryptedVehicleGPSWrite(
     const lngEncCol = `${lng}Enc` as keyof GPSEncShadowPayload;
 
     if (latVal === null || lngVal === null) {
-      // Clear both shadows. (If only one half is null we treat the
-      // pair as a clear — a mixed null/number pair would violate
-      // atomic-pair semantics and is rejected at read time anyway.)
+      if (latVal !== lngVal) {
+        // Mixed null / non-null pair. Clearing both shadows is the
+        // correct atomic-pair recovery, but the caller likely has a
+        // bug — surface it.
+        console.warn(
+          `[vehicle-gps-encryption] mixed null/number pair for (${lat}, ${lng}); clearing both shadows`,
+        );
+      }
       (out as Record<string, unknown>)[latEncCol] = null;
       (out as Record<string, unknown>)[lngEncCol] = null;
       continue;


### PR DESCRIPTION
## Summary

- Phase 1 of MYR-63 — application-layer encryption for the six P1-classified Vehicle GPS columns (`latitude`, `longitude`, `destinationLatitude`, `destinationLongitude`, `originLatitude`, `originLongitude`) per `data-classification.md` §1.3 and NFR-3.23.
- Adds the matching `*Enc TEXT NULL` shadow columns to `Vehicle` via additive migration. Existing `Float` columns remain as the read fallback during the dual-write window.
- Adds `src/lib/vehicle-gps-encryption.ts` with the `buildEncryptedVehicleGPSWrite` / `readVehicleGPS` helpers — mirrors the dual-write pattern landed for `Account` tokens in MYR-62 Phase 1.
- Wires the helpers at the only Next.js write path that touches GPS (`src/features/vehicles/api/sync.ts`) and at the read path that surfaces GPS to clients (`src/features/vehicles/api/vehicle-mappers.ts`).

## Atomic-pair design

`vehicle-state-schema.md` §3.3 GPS predicates require lat/lng to be a synchronized pair on the wire. The helper enforces that on both sides:

- **Write**: if a caller passes only one half (e.g., `latitude` without `longitude`), neither shadow column is touched — and a warning is logged. The plaintext payload still goes through the caller's spread, but the row's `*Enc` halves remain in their previous (consistent) state.
- **Read**: if one half of an `*Enc` pair is non-NULL but its mate is NULL, the helper treats the entire pair as `null` rather than returning a half-pair to consumers. Same warning-and-reject pattern.

## Float ↔ string conversion

Floats are encrypted as their canonical decimal string. Round-trip via `String(x)` then `Number(s)` is lossless on every finite IEEE-754 double — verified in the test `round-trips through the encryptor lossless on doubles` against `37.77491234567` / `-122.41947654321`.

## Helper return shape

`buildEncryptedVehicleGPSWrite` returns the **shadow payload only** (`{latitudeEnc?, longitudeEnc?, ...}`). Callers continue to spread their plaintext payload separately. This keeps the helper's return type compatible with Prisma's nullability — the Float columns are non-nullable for the main pair (`latitude`/`longitude`) but nullable for the destination/origin pairs, and the helper doesn't have to recreate that inconsistency.

## Migration plan

1. **Phase 1 (this PR)**: dual-write — every Vehicle write path populates BOTH the Float plaintext and the `*Enc` shadow.
2. **Phase 2 (separate PR in `tnando/my-robo-taxi-telemetry`)**: Go-side writer + reader pipeline through `internal/store/writer.go`, `internal/store/field_mapper.go`, `internal/store/vehicle_repo.go`. Adds backfill script + `vehicle_gps_plaintext_remaining_total` gauge mirroring MYR-62 Phase 2.
3. **Read-flip (separate post-rollout issue)**: reads stop falling back; writes still dual-write.
4. **Drop plaintext (final post-rollout issue)**: Float columns dropped once the gauge stays at zero ≥24h.

## Call sites updated

| File | Change |
|------|--------|
| `src/features/vehicles/api/sync.ts` | Spread `buildEncryptedVehicleGPSWrite(...)` into both the `create` and `update` payloads of the `prisma.vehicle.upsert`. Keeps the existing `hasValidCoords` skip semantics on `update`. |
| `src/features/vehicles/api/vehicle-mappers.ts` | Read all three pairs through `readVehicleGPS(prismaVehicle)` so the Vehicle DTO surfaces decrypted values. |
| `__tests__/setup.ts` | Set a deterministic `ENCRYPTION_KEY` default so any test exercising the cryptox code path works without having to stub the env. |

## Test plan

- [x] `npm run lint` — 0 errors (9 pre-existing warnings unrelated to this PR).
- [x] `npx vitest run` — 714/714 tests pass.
- [x] `npm run build` — clean.
- [x] `npx prisma migrate deploy` against dev Supabase — `*Enc` columns confirmed via `information_schema`.
- [x] 12 new unit tests in `__tests__/lib/vehicle-gps-encryption.test.ts` covering round-trip, lossless double precision, atomic-pair half-NULL on both read and write, all-three-pairs independence, and dual-read fallback.

## Cross-repo note

Phase 2 (Go-side AccountRepo-equivalent for `VehicleRepo` + writer pipeline + backfill + plaintext-remaining gauge + `data-classification.md` §3.3 foundation-status flip) ships in a separate PR against `tnando/my-robo-taxi-telemetry`. Reuses the existing cross-impl fixture from MYR-62 (`src/lib/cryptox/__fixtures__/cross-impl.json`).

## Anchored

NFR-3.23, NFR-3.24, NFR-3.25, NFR-3.26, NFR-3.1; `data-classification.md` §1.3; `vehicle-state-schema.md` §3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)