### PR TITLE
MYR-64 (Phase 1/TS) Encrypt route blobs + Prisma dual-write migration

### DIFF
--- a/__tests__/lib/route-blob-encryption.test.ts
+++ b/__tests__/lib/route-blob-encryption.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for `src/lib/route-blob-encryption.ts` — dual-write /
+ * dual-read helpers for the encrypted route-blob shadow columns
+ * (Vehicle.navRouteCoordinatesEnc, Drive.routePointsEnc) — MYR-64
+ * Phase 1.
+ */
+
+import { Buffer } from 'node:buffer';
+
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+
+import { __resetEncryptor } from '@/lib/account-encryption';
+import { KEY_LEN, newEncryptor, loadKeySetFromEnv } from '@/lib/cryptox';
+import {
+  buildEncryptedNavRouteWrite,
+  buildEncryptedRoutePointsWrite,
+  readNavRouteCoordinates,
+  readRoutePoints,
+  type NavRouteCoordinate,
+  type RoutePoint,
+} from '@/lib/route-blob-encryption';
+
+const TEST_KEY_B64 = Buffer.alloc(KEY_LEN, 0x44).toString('base64');
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  process.env.ENCRYPTION_KEY = TEST_KEY_B64;
+  __resetEncryptor();
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  delete process.env.ENCRYPTION_KEY;
+  __resetEncryptor();
+  warnSpy.mockRestore();
+});
+
+const sampleCoords: NavRouteCoordinate[] = [
+  [-122.4194, 37.7749],
+  [-122.41, 37.77],
+  [-122.405, 37.765],
+];
+
+const samplePoints: RoutePoint[] = [
+  { lat: 37.7749, lng: -122.4194, timestamp: '2026-01-01T00:00:00Z', speed: 0 },
+  { lat: 37.7755, lng: -122.4188, timestamp: '2026-01-01T00:00:01Z', speed: 12.3 },
+  { lat: 37.7762, lng: -122.4181, timestamp: '2026-01-01T00:00:02Z', speed: 18.7 },
+];
+
+describe('buildEncryptedNavRouteWrite', () => {
+  it('encrypts populated coordinates into the shadow column', () => {
+    const out = buildEncryptedNavRouteWrite(sampleCoords);
+    expect(out.navRouteCoordinatesEnc).toBeTruthy();
+    expect(typeof out.navRouteCoordinatesEnc).toBe('string');
+  });
+
+  it('clears the shadow on null', () => {
+    const out = buildEncryptedNavRouteWrite(null);
+    expect(out.navRouteCoordinatesEnc).toBeNull();
+  });
+
+  it('clears the shadow on empty array', () => {
+    const out = buildEncryptedNavRouteWrite([]);
+    expect(out.navRouteCoordinatesEnc).toBeNull();
+  });
+
+  it('leaves the shadow untouched on undefined', () => {
+    const out = buildEncryptedNavRouteWrite(undefined);
+    expect(out.navRouteCoordinatesEnc).toBeUndefined();
+  });
+
+  it('produces ciphertext that round-trips back to the input array', () => {
+    const out = buildEncryptedNavRouteWrite(sampleCoords);
+    const ks = loadKeySetFromEnv();
+    const enc = newEncryptor(ks);
+    const decoded = JSON.parse(enc.decryptString(out.navRouteCoordinatesEnc!));
+    expect(decoded).toEqual(sampleCoords);
+  });
+
+  it('handles a large polyline (5000 points)', () => {
+    const big: NavRouteCoordinate[] = Array.from({ length: 5000 }, (_, i) => [
+      -122 + i * 1e-5,
+      37 + i * 1e-5,
+    ]);
+    const out = buildEncryptedNavRouteWrite(big);
+    expect(out.navRouteCoordinatesEnc).toBeTruthy();
+    const ks = loadKeySetFromEnv();
+    const enc = newEncryptor(ks);
+    const decoded = JSON.parse(enc.decryptString(out.navRouteCoordinatesEnc!));
+    expect(decoded).toEqual(big);
+  });
+});
+
+describe('readNavRouteCoordinates', () => {
+  it('prefers *Enc when populated', () => {
+    const w = buildEncryptedNavRouteWrite(sampleCoords);
+    const out = readNavRouteCoordinates({
+      navRouteCoordinates: [[0, 0]],
+      navRouteCoordinatesEnc: w.navRouteCoordinatesEnc!,
+    });
+    expect(out).toEqual(sampleCoords);
+  });
+
+  it('falls back to plaintext when *Enc is null', () => {
+    const out = readNavRouteCoordinates({
+      navRouteCoordinates: sampleCoords,
+      navRouteCoordinatesEnc: null,
+    });
+    expect(out).toEqual(sampleCoords);
+  });
+
+  it('returns null when both columns are null', () => {
+    const out = readNavRouteCoordinates({
+      navRouteCoordinates: null,
+      navRouteCoordinatesEnc: null,
+    });
+    expect(out).toBeNull();
+  });
+
+  it('falls back to plaintext on decrypt failure + warns', () => {
+    const out = readNavRouteCoordinates({
+      navRouteCoordinates: sampleCoords,
+      navRouteCoordinatesEnc: 'bogus-not-real-ciphertext',
+    });
+    expect(out).toEqual(sampleCoords);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'navRouteCoordinatesEnc decrypt/parse failed',
+      ),
+    );
+  });
+
+  it('falls back to plaintext when *Enc decodes to non-array + warns', () => {
+    const ks = loadKeySetFromEnv();
+    const enc = newEncryptor(ks);
+    const badEnc = enc.encryptString(JSON.stringify({ not: 'an array' }));
+    const out = readNavRouteCoordinates({
+      navRouteCoordinates: sampleCoords,
+      navRouteCoordinatesEnc: badEnc,
+    });
+    expect(out).toEqual(sampleCoords);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('decoded to non-array'),
+    );
+  });
+});
+
+describe('buildEncryptedRoutePointsWrite', () => {
+  it('encrypts populated points into the shadow column', () => {
+    const out = buildEncryptedRoutePointsWrite(samplePoints);
+    expect(out.routePointsEnc).toBeTruthy();
+  });
+
+  it('clears the shadow on null / empty array', () => {
+    expect(buildEncryptedRoutePointsWrite(null).routePointsEnc).toBeNull();
+    expect(buildEncryptedRoutePointsWrite([]).routePointsEnc).toBeNull();
+  });
+
+  it('leaves the shadow untouched on undefined', () => {
+    const out = buildEncryptedRoutePointsWrite(undefined);
+    expect(out.routePointsEnc).toBeUndefined();
+  });
+
+  it('round-trips through the encryptor', () => {
+    const out = buildEncryptedRoutePointsWrite(samplePoints);
+    const ks = loadKeySetFromEnv();
+    const enc = newEncryptor(ks);
+    const decoded = JSON.parse(enc.decryptString(out.routePointsEnc!));
+    expect(decoded).toEqual(samplePoints);
+  });
+});
+
+describe('readRoutePoints', () => {
+  it('prefers *Enc when populated', () => {
+    const w = buildEncryptedRoutePointsWrite(samplePoints);
+    const out = readRoutePoints({
+      routePoints: [],
+      routePointsEnc: w.routePointsEnc!,
+    });
+    expect(out).toEqual(samplePoints);
+  });
+
+  it('falls back to plaintext when *Enc is null', () => {
+    const out = readRoutePoints({
+      routePoints: samplePoints,
+      routePointsEnc: null,
+    });
+    expect(out).toEqual(samplePoints);
+  });
+
+  it('returns empty array when both columns are absent', () => {
+    expect(readRoutePoints({})).toEqual([]);
+  });
+
+  it('falls back to plaintext on decrypt failure + warns', () => {
+    const out = readRoutePoints({
+      routePoints: samplePoints,
+      routePointsEnc: 'bogus-not-real-ciphertext',
+    });
+    expect(out).toEqual(samplePoints);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('routePointsEnc decrypt/parse failed'),
+    );
+  });
+
+  it('falls back to plaintext on non-array decode + warns', () => {
+    const ks = loadKeySetFromEnv();
+    const enc = newEncryptor(ks);
+    const badEnc = enc.encryptString(JSON.stringify({ not: 'an array' }));
+    const out = readRoutePoints({
+      routePoints: samplePoints,
+      routePointsEnc: badEnc,
+    });
+    expect(out).toEqual(samplePoints);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('decoded to non-array'),
+    );
+  });
+});

--- a/prisma/migrations/20260509182821_add_route_blob_enc_columns/migration.sql
+++ b/prisma/migrations/20260509182821_add_route_blob_enc_columns/migration.sql
@@ -1,0 +1,36 @@
+-- MYR-64 Phase 1 — encrypted shadows for route-blob columns.
+--
+-- Adds two nullable TEXT columns for the dual-write rollout of P1
+-- route polylines per data-classification.md §1.4 and NFR-3.23:
+--
+--   • Vehicle.navRouteCoordinatesEnc — Tesla's planned navigation
+--     polyline (the "where the car is going" route, member of the
+--     navigation atomic group). Plaintext column is `Json?`.
+--   • Drive.routePointsEnc           — recorded drive route polyline
+--     (the historical breadcrumb trail of a completed drive).
+--     Plaintext column is non-nullable `Json`.
+--
+-- Wire format owned by lib/cryptox (TS) and internal/cryptox (Go):
+--   [1B version=0x01][12B nonce][N B ct + 16B tag], base64(StdEncoding).
+-- The plaintext value is JSON.stringify'd at the encryption boundary,
+-- so the ciphertext is a serialized string regardless of the column
+-- shape (object array vs tuple array).
+--
+-- Dual-write semantics (mirrors MYR-62 / MYR-63):
+--   1. Writes go to BOTH the plaintext Json column AND the *Enc TEXT
+--      shadow during the rollout window.
+--   2. Reads prefer *Enc (decrypt + JSON.parse), fall back to the
+--      plaintext Json column for legacy rows.
+--   3. Backfill happens in a separate post-rollout issue.
+--   4. The plaintext columns will be dropped in a separate
+--      post-rollout migration once backfill completes.
+--
+-- Additive only — no rewrite of existing rows. Phase 2 in the
+-- my-robo-taxi-telemetry repo wires the Go writer/reader through the
+-- field mapper + repos using the same dual-write contract.
+
+ALTER TABLE "Vehicle"
+  ADD COLUMN "navRouteCoordinatesEnc" TEXT;
+
+ALTER TABLE "Drive"
+  ADD COLUMN "routePointsEnc" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,6 +100,12 @@ model Vehicle {
   tripDistanceMiles     Float?
   tripDistanceRemaining Float?
   navRouteCoordinates   Json?
+  // MYR-64 Phase 1 — encrypted shadow column for the live nav-route
+  // polyline (P1 per data-classification.md §1.4). Dual-write window:
+  // writes go to BOTH Json plaintext AND TEXT ciphertext; reads prefer
+  // *Enc with JSON.stringify/parse at the crypto boundary, plaintext
+  // fallback. See src/lib/route-blob-encryption.ts.
+  navRouteCoordinatesEnc String?
   lastUpdated           DateTime      @default(now())
   createdAt             DateTime      @default(now())
   updatedAt             DateTime      @updatedAt
@@ -166,6 +172,12 @@ model Drive {
   fsdPercentage    Float
   interventions    Int
   routePoints      Json
+  // MYR-64 Phase 1 — encrypted shadow column for the recorded drive
+  // route polyline (P1 per data-classification.md §1.4). Dual-write
+  // window: writes go to BOTH Json plaintext AND TEXT ciphertext; reads
+  // prefer *Enc with JSON.stringify/parse at the crypto boundary,
+  // plaintext fallback. See src/lib/route-blob-encryption.ts.
+  routePointsEnc   String?
   createdAt        DateTime @default(now())
   vehicle          Vehicle  @relation(fields: [vehicleId], references: [id], onDelete: Cascade)
 

--- a/src/features/drives/api/actions.ts
+++ b/src/features/drives/api/actions.ts
@@ -7,20 +7,28 @@ import { auth } from '@/auth';
 import { normalizeRoutePoints } from '@/features/drives/api/normalize-route-points';
 import { formatLocation, formatTime } from '@/lib/format';
 import { prisma } from '@/lib/prisma';
+import { readRoutePoints } from '@/lib/route-blob-encryption';
 import type { Drive, DriveSortBy } from '@/types/drive';
 
 /**
  * Map a Prisma Drive record to the shared Drive interface.
  * Converts RoutePoint objects to LngLat tuples and formats time/location fields.
+ *
+ * MYR-64 Phase 1 dual-read: route points are sourced via
+ * `readRoutePoints`, which prefers the encrypted shadow column with a
+ * plaintext fallback. The decoded value still flows through
+ * `normalizeRoutePoints` to coerce stored RoutePoint objects (and
+ * legacy mock-data LngLat tuples) into the canonical `LngLat[]` shape.
  */
-function mapDrive({ createdAt, routePoints, ...rest }: PrismaDrive): Drive {
+function mapDrive({ createdAt, routePoints, routePointsEnc, ...rest }: PrismaDrive): Drive {
+  const decoded = readRoutePoints({ routePoints, routePointsEnc });
   return {
     ...rest,
     startTime: formatTime(rest.startTime),
     endTime: formatTime(rest.endTime),
     startLocation: formatLocation(rest.startLocation),
     endLocation: formatLocation(rest.endLocation),
-    routePoints: normalizeRoutePoints(routePoints),
+    routePoints: normalizeRoutePoints(decoded),
   };
 }
 

--- a/src/features/vehicles/api/vehicle-mappers.ts
+++ b/src/features/vehicles/api/vehicle-mappers.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client';
 
+import { readNavRouteCoordinates } from '@/lib/route-blob-encryption';
 import { readVehicleGPS } from '@/lib/vehicle-gps-encryption';
 import { VALID_GEARS } from '@/types/vehicle';
 import type { Vehicle, TripStop, VehicleStatus, GearPosition, SetupStatus } from '@/types/vehicle';
@@ -134,8 +135,12 @@ export function mapPrismaVehicleToVehicle(prismaVehicle: PrismaVehicleWithStops)
   if (prismaVehicle.tripDistanceRemaining != null) {
     vehicle.tripDistanceRemaining = prismaVehicle.tripDistanceRemaining;
   }
-  if (prismaVehicle.navRouteCoordinates != null) {
-    vehicle.navRouteCoordinates = prismaVehicle.navRouteCoordinates as [number, number][];
+  // Dual-read for the encrypted nav-route shadow column (MYR-64 Phase 1).
+  // Decrypt failures fall through to plaintext with a warn — corruption
+  // of a 100KB+ blob must not 500 the request.
+  const navRoute = readNavRouteCoordinates(prismaVehicle);
+  if (navRoute != null) {
+    vehicle.navRouteCoordinates = navRoute;
   }
   if (stops.length > 0) {
     vehicle.stops = stops;

--- a/src/lib/drive-detection.ts
+++ b/src/lib/drive-detection.ts
@@ -17,6 +17,10 @@ import { totalDistanceFromRoutePoints } from '@/lib/geo';
 import type { RoutePoint } from '@/lib/geo';
 import { reverseGeocode } from '@/lib/geocode';
 import { prisma } from '@/lib/prisma';
+import {
+  buildEncryptedRoutePointsWrite,
+  readRoutePoints,
+} from '@/lib/route-blob-encryption';
 import type { VehicleStatus } from '@/types/vehicle';
 
 // Re-export for consumers
@@ -91,6 +95,7 @@ async function startDrive(input: DriveDetectionInput): Promise<void> {
     lat: input.latitude, lng: input.longitude,
     timestamp: now.toISOString(), speed: input.speed,
   };
+  const initialPoints: RoutePoint[] = [point];
 
   // Reverse geocode start location (graceful fallback to coords on failure)
   const geo = await reverseGeocode(input.latitude, input.longitude);
@@ -117,7 +122,9 @@ async function startDrive(input: DriveDetectionInput): Promise<void> {
       fsdMiles: 0,
       fsdPercentage: 0,
       interventions: 0,
-      routePoints: [point] as unknown as Prisma.InputJsonValue,
+      routePoints: initialPoints as unknown as Prisma.InputJsonValue,
+      // MYR-64 dual-write: encrypted shadow alongside the plaintext Json.
+      ...buildEncryptedRoutePointsWrite(initialPoints),
     },
   });
 
@@ -130,11 +137,12 @@ async function updateActiveDrive(
 ): Promise<void> {
   const drive = await prisma.drive.findUnique({
     where: { id: driveId },
-    select: { routePoints: true, maxSpeedMph: true },
+    select: { routePoints: true, routePointsEnc: true, maxSpeedMph: true },
   });
   if (!drive) return;
 
-  const routePoints = (drive.routePoints as unknown as RoutePoint[]) ?? [];
+  // Dual-read: prefer the encrypted shadow, fall back to plaintext.
+  const routePoints = readRoutePoints(drive);
   routePoints.push({
     lat: input.latitude, lng: input.longitude,
     timestamp: new Date().toISOString(), speed: input.speed,
@@ -144,6 +152,8 @@ async function updateActiveDrive(
     where: { id: driveId },
     data: {
       routePoints: routePoints as unknown as Prisma.InputJsonValue,
+      // MYR-64 dual-write: encrypted shadow alongside the plaintext Json.
+      ...buildEncryptedRoutePointsWrite(routePoints),
       maxSpeedMph: Math.max(drive.maxSpeedMph, input.speed),
     },
   });
@@ -168,7 +178,8 @@ async function endDrive(
     (now.getTime() - startTime.getTime()) / 60_000,
   );
 
-  const routePoints = (drive.routePoints as unknown as RoutePoint[]) ?? [];
+  // Dual-read: prefer the encrypted shadow, fall back to plaintext.
+  const routePoints = readRoutePoints(drive);
 
   // Add final point if we have valid coordinates
   if (hasEndCoords) {
@@ -224,6 +235,8 @@ async function endDrive(
       energyUsedKwh,
       endChargeLevel: input.chargeLevel,
       routePoints: routePoints as unknown as Prisma.InputJsonValue,
+      // MYR-64 dual-write: encrypted shadow alongside the plaintext Json.
+      ...buildEncryptedRoutePointsWrite(routePoints),
     },
   });
 

--- a/src/lib/route-blob-encryption.ts
+++ b/src/lib/route-blob-encryption.ts
@@ -1,0 +1,218 @@
+/**
+ * Route-blob encryption helpers (MYR-64 Phase 1 — TS side).
+ *
+ * Centralises the dual-write/dual-read pattern for the encrypted
+ * shadow columns added to the two large P1-classified route polylines
+ * (data-classification.md §1.4, NFR-3.23):
+ *
+ *   • Vehicle.navRouteCoordinatesEnc — Tesla's planned navigation
+ *     polyline ("where the car is going" — destination route, member
+ *     of the navigation atomic group). Plaintext column type: `Json?`.
+ *   • Drive.routePointsEnc           — recorded drive route polyline
+ *     (the historical breadcrumb trail of a completed drive).
+ *     Plaintext column type: non-nullable `Json`.
+ *
+ * Wire format owned by lib/cryptox (TS) and internal/cryptox (Go):
+ *   [1B version=0x01][12B nonce][N B ct + 16B tag], base64(StdEncoding).
+ * The plaintext value is JSON.stringify'd at the encryption boundary,
+ * so the ciphertext is always a serialized string regardless of the
+ * column shape (object array vs tuple array). The decrypt boundary
+ * JSON.parses the result back into the typed shape.
+ *
+ * Empty-array semantics align with the cryptox empty-string sentinel:
+ * `encryptString("")` returns `""`, so an empty array (`[]`) — or any
+ * "absent value" — yields a `null` shadow rather than an encrypted
+ * empty string.
+ *
+ * Decrypt errors do NOT throw: route blobs can be 100KB+ and a key
+ * rotation gone wrong should not 500 the live nav-route view. The
+ * helper logs `console.warn` and falls back to the plaintext column.
+ *
+ * Rollout phases mirror MYR-62 / MYR-63:
+ *   1. Dual-write (this PR — TS Phase 1)
+ *   2. Phase 2 — Go telemetry pipeline (separate, my-robo-taxi-telemetry)
+ *   3. Backfill — separate post-rollout issue
+ *   4. Read-flip — separate post-rollout issue
+ *   5. Drop plaintext columns — separate post-rollout issue
+ */
+
+import { getEncryptor } from '@/lib/account-encryption';
+
+// ─── Shape contracts ─────────────────────────────────────────────────────────
+
+/**
+ * Tesla's planned navigation polyline. Stored as `[lng, lat]` tuples
+ * in `Vehicle.navRouteCoordinates` per the existing schema (matches
+ * Mapbox/GeoJSON ordering). The Go telemetry server is the only
+ * writer in production; the TS app reads via `vehicle-mappers.ts`.
+ */
+export type NavRouteCoordinate = [number, number];
+
+/**
+ * A single recorded route point as written by `lib/drive-detection`.
+ * The shape is intentionally narrow: any extra fields the writer
+ * passes survive the JSON.stringify roundtrip without re-declaring
+ * them here.
+ */
+export interface RoutePoint {
+  lat: number;
+  lng: number;
+  timestamp: string;
+  speed: number;
+}
+
+// ─── Vehicle.navRouteCoordinates ────────────────────────────────────────────
+
+/**
+ * The slice of a Vehicle row used for nav-route reads. Both columns
+ * are nullable: legacy rows have only the plaintext `Json?`, dual-write
+ * rows populate both, post-read-flip rows will populate only `*Enc`.
+ */
+export interface NavRouteFields {
+  navRouteCoordinates?: unknown;
+  navRouteCoordinatesEnc?: string | null;
+}
+
+export interface NavRouteEncShadowPayload {
+  navRouteCoordinatesEnc?: string | null;
+}
+
+/**
+ * Build the encrypted-shadow payload for a Vehicle create/update/upsert
+ * touching `navRouteCoordinates`. Returns ONLY the `*Enc` column;
+ * callers continue to write the plaintext Json column from their own
+ * data via spread.
+ *
+ * Semantics:
+ *   • `undefined`            → leave the shadow column untouched.
+ *   • `null` / empty array   → clear the shadow column (`null`).
+ *   • populated array        → JSON.stringify + encrypt into `*Enc`.
+ */
+export function buildEncryptedNavRouteWrite(
+  coords: NavRouteCoordinate[] | null | undefined,
+): NavRouteEncShadowPayload {
+  if (coords === undefined) return {};
+  if (coords === null || coords.length === 0) {
+    return { navRouteCoordinatesEnc: null };
+  }
+  const json = JSON.stringify(coords);
+  return { navRouteCoordinatesEnc: getEncryptor().encryptString(json) };
+}
+
+/**
+ * Read `Vehicle.navRouteCoordinates`, preferring the encrypted shadow
+ * with plaintext fallback.
+ *
+ * Returns `null` for absent data. Decrypt or JSON.parse failures fall
+ * through to the plaintext column with a `console.warn` — corruption
+ * of a 100KB+ blob must not 500 the request.
+ */
+export function readNavRouteCoordinates(
+  row: NavRouteFields,
+): NavRouteCoordinate[] | null {
+  const enc = row.navRouteCoordinatesEnc;
+  if (enc != null && enc !== '') {
+    try {
+      const plaintext = getEncryptor().decryptString(enc);
+      if (plaintext === '') {
+        // Empty-string sentinel — fall through to plaintext fallback.
+      } else {
+        const parsed = JSON.parse(plaintext) as unknown;
+        if (Array.isArray(parsed)) {
+          return parsed as NavRouteCoordinate[];
+        }
+        console.warn(
+          '[route-blob-encryption] navRouteCoordinatesEnc decoded to non-array; falling back to plaintext',
+        );
+      }
+    } catch (err) {
+      console.warn(
+        `[route-blob-encryption] navRouteCoordinatesEnc decrypt/parse failed; falling back to plaintext: ${
+          (err as Error).message
+        }`,
+      );
+    }
+  }
+
+  const plain = row.navRouteCoordinates;
+  if (plain == null) return null;
+  if (Array.isArray(plain)) return plain as NavRouteCoordinate[];
+  return null;
+}
+
+// ─── Drive.routePoints ──────────────────────────────────────────────────────
+
+/**
+ * The slice of a Drive row used for routePoints reads. The plaintext
+ * column is non-nullable on the schema, but at the read boundary we
+ * accept partial rows (some queries `select` a narrow set of columns).
+ */
+export interface RoutePointsFields {
+  routePoints?: unknown;
+  routePointsEnc?: string | null;
+}
+
+export interface RoutePointsEncShadowPayload {
+  routePointsEnc?: string | null;
+}
+
+/**
+ * Build the encrypted-shadow payload for a Drive create/update touching
+ * `routePoints`. Returns ONLY the `*Enc` column; the caller continues
+ * to write the plaintext Json column from its own data via spread.
+ *
+ * Semantics mirror `buildEncryptedNavRouteWrite`:
+ *   • `undefined`            → leave the shadow column untouched.
+ *   • `null` / empty array   → clear the shadow column (`null`).
+ *   • populated array        → JSON.stringify + encrypt into `*Enc`.
+ */
+export function buildEncryptedRoutePointsWrite(
+  points: RoutePoint[] | null | undefined,
+): RoutePointsEncShadowPayload {
+  if (points === undefined) return {};
+  if (points === null || points.length === 0) {
+    return { routePointsEnc: null };
+  }
+  const json = JSON.stringify(points);
+  return { routePointsEnc: getEncryptor().encryptString(json) };
+}
+
+/**
+ * Read `Drive.routePoints`, preferring the encrypted shadow with
+ * plaintext fallback. Returns an empty array for absent data — the
+ * column is non-nullable on the schema, but legacy rows may carry
+ * `[]` and downstream code already treats nullish as empty.
+ *
+ * Decrypt or JSON.parse failures fall through to the plaintext column
+ * with a `console.warn` — same rationale as readNavRouteCoordinates.
+ */
+export function readRoutePoints(row: RoutePointsFields): RoutePoint[] {
+  const enc = row.routePointsEnc;
+  if (enc != null && enc !== '') {
+    try {
+      const plaintext = getEncryptor().decryptString(enc);
+      if (plaintext === '') {
+        // Empty-string sentinel — fall through to plaintext fallback.
+      } else {
+        const parsed = JSON.parse(plaintext) as unknown;
+        if (Array.isArray(parsed)) {
+          return parsed as RoutePoint[];
+        }
+        console.warn(
+          '[route-blob-encryption] routePointsEnc decoded to non-array; falling back to plaintext',
+        );
+      }
+    } catch (err) {
+      console.warn(
+        `[route-blob-encryption] routePointsEnc decrypt/parse failed; falling back to plaintext: ${
+          (err as Error).message
+        }`,
+      );
+    }
+  }
+
+  const plain = row.routePoints;
+  if (plain == null) return [];
+  if (Array.isArray(plain)) return plain as RoutePoint[];
+  return [];
+}


### PR DESCRIPTION
## Summary

- Phase 1 of MYR-64 — application-layer encryption for the two large P1-classified route polylines (`Vehicle.navRouteCoordinates`, `Drive.routePoints`) per `data-classification.md` §1.4 and NFR-3.23.
- Adds `*Enc TEXT NULL` shadow columns via additive Prisma migration. Plaintext `Json` columns remain as the read fallback during dual-write.
- Adds `src/lib/route-blob-encryption.ts` with `buildEncryptedNavRouteWrite` / `readNavRouteCoordinates` and `buildEncryptedRoutePointsWrite` / `readRoutePoints` — mirrors the pattern landed for Account tokens (MYR-62) and Vehicle GPS (MYR-63).
- Wires the helpers at the writers (`src/lib/drive-detection.ts`) and the readers (`src/features/drives/api/actions.ts`, `src/features/vehicles/api/vehicle-mappers.ts`).

## JSON.stringify boundary

The plaintext columns are `Json` (object array for `routePoints`, tuple array for `navRouteCoordinates`). At the encryption boundary we `JSON.stringify` and pass the resulting string into `cryptox.encryptString`. At decrypt we `JSON.parse` and validate the shape is `Array`. Non-array decode → fall back to plaintext + warn.

## Why decrypt failure falls back instead of throwing

These blobs can be 100KB+. A key rotation gone wrong, a corrupted ciphertext, or an unknown version byte should not 500 the live nav-route view or the drive detail page. The helpers log `console.warn` and return the plaintext column. The plaintext column will eventually be dropped (separate post-rollout issue once the gauge stays at zero ≥24h), at which point this fallback becomes a no-op — but for the dual-write window it's the correct safety net.

## Helper return shape (consistent with MYR-63 pattern)

`buildEncryptedNavRouteWrite` and `buildEncryptedRoutePointsWrite` return **shadow-only payloads** (`{navRouteCoordinatesEnc?}` and `{routePointsEnc?}`). Callers continue to spread their plaintext payload separately. This keeps the helper's return type compatible with Prisma's `Json` typing on the plaintext columns.

## Empty-array semantics

Aligned with the cryptox empty-string sentinel (`encryptString("")` → `""`):
- `null` or `[]` input → shadow column set to `null` (not encrypted empty string).
- `undefined` → shadow column untouched (Prisma drops `undefined`).
- Populated array → JSON-encoded ciphertext.

This matches the existing app's "absent value" semantics — empty array and null are both "no nav route".

## Migration plan

1. **Phase 1 (this PR)**: dual-write — every write path populates BOTH the Json plaintext and the `*Enc` shadow.
2. **Phase 2 (separate PR in `tnando/my-robo-taxi-telemetry`)**: Go-side telemetry pipeline — the Go server is the dominant writer of `Vehicle.navRouteCoordinates`. Adds backfill script + `route_blob_plaintext_remaining_total` gauge mirroring MYR-62 / MYR-63 Phase 2.
3. **Read-flip (separate post-rollout issue)**: reads stop falling back; writes still dual-write.
4. **Drop plaintext (final post-rollout issue)**: Json columns dropped once the gauge stays at zero ≥24h.

## Call sites updated

| File | Change |
|------|--------|
| `src/lib/drive-detection.ts` | Drive create/update writes spread `buildEncryptedRoutePointsWrite(...)` alongside the plaintext `routePoints` write. Reads use `readRoutePoints(drive)` after a `select: { routePoints: true, routePointsEnc: true }`. |
| `src/features/drives/api/actions.ts` | `mapDrive` reads via `readRoutePoints`. |
| `src/features/vehicles/api/vehicle-mappers.ts` | `readNavRouteCoordinates(prismaVehicle)` for the navigation polyline. The Next.js app does NOT write `Vehicle.navRouteCoordinates` — that's the Go telemetry server's path, wired in Phase 2. |

## Test plan

- [x] `npm run lint` — 0 errors (9 pre-existing warnings unrelated to this PR).
- [x] `npx vitest run` — 734/734 tests pass.
- [x] `npm run build` — clean.
- [x] `npx prisma migrate deploy` against dev Supabase — `*Enc` columns confirmed.
- [x] 20 new unit tests in `__tests__/lib/route-blob-encryption.test.ts` covering: round-trip per blob type, lossless 5000-point polyline, null/empty/undefined input, dual-read fallback, decrypt-failure-and-warn, non-array-decode-and-warn.

## Cross-repo note

Phase 2 (Go-side telemetry pipeline encrypting `Vehicle.navRouteCoordinates` writes from telemetry frames + a Drive route writer if any + backfill + plaintext-remaining gauge + `data-classification.md` §3.3 foundation-status flip for "route blobs") ships in a separate PR against `tnando/my-robo-taxi-telemetry`. Reuses the existing cross-impl fixture (`internal/cryptox/testdata/cross-impl.json`, SHA256 `409ccb4a0fd6bff1bd1d97691e9fd17fccbf7f7171561a8a1ebc61b012c7fa8e`).

## Anchored

NFR-3.23, NFR-3.24, NFR-3.25, NFR-3.26; `data-classification.md` §1.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)