### PR TITLE
MYR-76 Implement recent-login re-auth gate on DELETE /api/users/me + /export

### DIFF
--- a/__tests__/app/api/users/me/export/route.test.ts
+++ b/__tests__/app/api/users/me/export/route.test.ts
@@ -421,6 +421,41 @@ describe('GET /api/users/me/export', () => {
       });
       expect(mockTransaction).not.toHaveBeenCalled();
     });
+
+    it('accepts a session at the edge of the window (5 min minus 1 s)', async () => {
+      // Freeze Date.now() so the handler's internal `now` matches the
+      // test's `edge` derivation exactly — defends against CI-load flake.
+      const FROZEN_MS = 1_730_000_000_000;
+      vi.spyOn(Date, 'now').mockReturnValue(FROZEN_MS);
+      const edge = Math.floor(FROZEN_MS / 1000) - (5 * 60 - 1);
+      mockAuth.mockResolvedValue({
+        user: { id: USER_ID, authTime: edge },
+      });
+
+      const res = await GET();
+
+      expect(res.status).toBe(200);
+      expect(mockTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('honors REAUTH_MAX_AGE_SEC override', async () => {
+      const prev = process.env.REAUTH_MAX_AGE_SEC;
+      process.env.REAUTH_MAX_AGE_SEC = '60';
+      try {
+        // 90 s ago — passes 5 min default but fails the 60 s override.
+        mockAuth.mockResolvedValue({
+          user: { id: USER_ID, authTime: Math.floor(Date.now() / 1000) - 90 },
+        });
+        const res = await GET();
+        expect(res.status).toBe(401);
+        expect(await res.json()).toMatchObject({
+          error: { subCode: 'reauth_required' },
+        });
+      } finally {
+        if (prev === undefined) delete process.env.REAUTH_MAX_AGE_SEC;
+        else process.env.REAUTH_MAX_AGE_SEC = prev;
+      }
+    });
   });
 
   describe('round-trip — seeded user with full ownership graph', () => {

--- a/__tests__/app/api/users/me/export/route.test.ts
+++ b/__tests__/app/api/users/me/export/route.test.ts
@@ -116,6 +116,11 @@ const USER_ID = 'cuid_user_export_aaaaaaaaaaaaaa';
 const OTHER_USER_ID = 'cuid_user_other_bbbbbbbbbbbbbb';
 const NEW_AUDIT_ID = 'cuid_audit_export_cccccccccccc';
 
+/** MYR-76 re-auth gate: 30 s ago — well under the default 5 min window. */
+function recentAuthTime(): number {
+  return Math.floor(Date.now() / 1000) - 30;
+}
+
 const NOW = new Date('2026-05-08T12:00:00.000Z');
 
 function seedUser() {
@@ -372,7 +377,9 @@ describe('GET /api/users/me/export', () => {
     });
 
     it('returns 401 auth_failed when authenticated but user row is missing', async () => {
-      mockAuth.mockResolvedValue({ user: { id: USER_ID } });
+      mockAuth.mockResolvedValue({
+        user: { id: USER_ID, authTime: recentAuthTime() },
+      });
       mockUserFindUnique.mockResolvedValue(null);
 
       const res = await GET();
@@ -383,9 +390,44 @@ describe('GET /api/users/me/export', () => {
     });
   });
 
+  describe('MYR-76 recent-login re-auth gate', () => {
+    it('returns 401 auth_failed{subCode: reauth_required} when authTime is missing', async () => {
+      mockAuth.mockResolvedValue({ user: { id: USER_ID } });
+
+      const res = await GET();
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({
+        error: {
+          code: 'auth_failed',
+          message: 'recent re-authentication required',
+          subCode: 'reauth_required',
+        },
+      });
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 reauth_required when authTime is older than the 5-min window', async () => {
+      const stale = Math.floor(Date.now() / 1000) - 10 * 60;
+      mockAuth.mockResolvedValue({
+        user: { id: USER_ID, authTime: stale },
+      });
+
+      const res = await GET();
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toMatchObject({
+        error: { code: 'auth_failed', subCode: 'reauth_required' },
+      });
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+  });
+
   describe('round-trip — seeded user with full ownership graph', () => {
     beforeEach(() => {
-      mockAuth.mockResolvedValue({ user: { id: USER_ID } });
+      mockAuth.mockResolvedValue({
+        user: { id: USER_ID, authTime: recentAuthTime() },
+      });
     });
 
     it('returns 200 with every owned row in the archive', async () => {
@@ -534,7 +576,9 @@ describe('GET /api/users/me/export', () => {
 
   describe('security regression — OAuth token columns must NEVER appear', () => {
     beforeEach(() => {
-      mockAuth.mockResolvedValue({ user: { id: USER_ID } });
+      mockAuth.mockResolvedValue({
+        user: { id: USER_ID, authTime: recentAuthTime() },
+      });
     });
 
     it('account entries do not carry plaintext OAuth tokens', async () => {
@@ -577,7 +621,9 @@ describe('GET /api/users/me/export', () => {
 
   describe('encryption boundary — *Enc columns are decrypted, not echoed', () => {
     beforeEach(() => {
-      mockAuth.mockResolvedValue({ user: { id: USER_ID } });
+      mockAuth.mockResolvedValue({
+        user: { id: USER_ID, authTime: recentAuthTime() },
+      });
     });
 
     it('vehicle output exposes decrypted GPS, never the raw *Enc strings', async () => {
@@ -612,7 +658,9 @@ describe('GET /api/users/me/export', () => {
 
   describe('failure handling', () => {
     beforeEach(() => {
-      mockAuth.mockResolvedValue({ user: { id: USER_ID } });
+      mockAuth.mockResolvedValue({
+        user: { id: USER_ID, authTime: recentAuthTime() },
+      });
     });
 
     it('returns 500 internal_error when a query throws', async () => {

--- a/__tests__/app/api/users/me/route.test.ts
+++ b/__tests__/app/api/users/me/route.test.ts
@@ -168,7 +168,12 @@ describe('DELETE /api/users/me', () => {
     });
 
     it('accepts a session at the edge of the window (5 min minus 1 s)', async () => {
-      const edge = Math.floor(Date.now() / 1000) - (5 * 60 - 1);
+      // Freeze Date.now() so the handler's internal `now` matches the
+      // test's `edge` derivation exactly — defends against CI-load flake
+      // when the two calls straddle a second boundary.
+      const FROZEN_MS = 1_730_000_000_000;
+      vi.spyOn(Date, 'now').mockReturnValue(FROZEN_MS);
+      const edge = Math.floor(FROZEN_MS / 1000) - (5 * 60 - 1);
       mockAuth.mockResolvedValue({
         user: { id: USER_ID, authTime: edge },
       });

--- a/__tests__/app/api/users/me/route.test.ts
+++ b/__tests__/app/api/users/me/route.test.ts
@@ -78,6 +78,15 @@ import { DELETE } from '@/app/api/users/me/route';
 const USER_ID = 'cuid_user_1234567890abcdef';
 const AUDIT_LOG_ID = 'cuid_audit_abcdef1234567890';
 
+/**
+ * MYR-76 re-auth gate: every test that expects the handler to reach the
+ * transaction must seed a recent `authTime`. Tests that exercise the gate
+ * itself override this to a stale value or omit it entirely.
+ */
+function recentAuthTime(): number {
+  return Math.floor(Date.now() / 1000) - 30; // 30 s ago — well under 5 min
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -124,9 +133,77 @@ describe('DELETE /api/users/me', () => {
     });
   });
 
+  describe('MYR-76 recent-login re-auth gate', () => {
+    it('returns 401 auth_failed{subCode: reauth_required} when authTime is missing', async () => {
+      // Legacy session (predates the JWT claim rollout) — must reauth.
+      mockAuth.mockResolvedValue({ user: { id: USER_ID } });
+
+      const res = await DELETE();
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({
+        error: {
+          code: 'auth_failed',
+          message: 'recent re-authentication required',
+          subCode: 'reauth_required',
+        },
+      });
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 reauth_required when authTime is older than the 5-min window', async () => {
+      // 10 minutes ago — outside the default 300 s window.
+      const stale = Math.floor(Date.now() / 1000) - 10 * 60;
+      mockAuth.mockResolvedValue({
+        user: { id: USER_ID, authTime: stale },
+      });
+
+      const res = await DELETE();
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toMatchObject({
+        error: { code: 'auth_failed', subCode: 'reauth_required' },
+      });
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+
+    it('accepts a session at the edge of the window (5 min minus 1 s)', async () => {
+      const edge = Math.floor(Date.now() / 1000) - (5 * 60 - 1);
+      mockAuth.mockResolvedValue({
+        user: { id: USER_ID, authTime: edge },
+      });
+
+      const res = await DELETE();
+
+      expect(res.status).toBe(200);
+      expect(mockTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('honors REAUTH_MAX_AGE_SEC override', async () => {
+      const prev = process.env.REAUTH_MAX_AGE_SEC;
+      process.env.REAUTH_MAX_AGE_SEC = '60';
+      try {
+        // 90 s ago — would pass the 5 min default but fails the 60 s override.
+        mockAuth.mockResolvedValue({
+          user: { id: USER_ID, authTime: Math.floor(Date.now() / 1000) - 90 },
+        });
+        const res = await DELETE();
+        expect(res.status).toBe(401);
+        expect(await res.json()).toMatchObject({
+          error: { subCode: 'reauth_required' },
+        });
+      } finally {
+        if (prev === undefined) delete process.env.REAUTH_MAX_AGE_SEC;
+        else process.env.REAUTH_MAX_AGE_SEC = prev;
+      }
+    });
+  });
+
   describe('happy path — seeded user with vehicles + drives + invites', () => {
     beforeEach(() => {
-      mockAuth.mockResolvedValue({ user: { id: USER_ID } });
+      mockAuth.mockResolvedValue({
+        user: { id: USER_ID, authTime: recentAuthTime() },
+      });
     });
 
     it('returns 200 with {deleted: true, auditLogId} on success', async () => {
@@ -268,7 +345,9 @@ describe('DELETE /api/users/me', () => {
 
   describe('rollback — audit insert failure aborts the transaction', () => {
     beforeEach(() => {
-      mockAuth.mockResolvedValue({ user: { id: USER_ID } });
+      mockAuth.mockResolvedValue({
+        user: { id: USER_ID, authTime: recentAuthTime() },
+      });
     });
 
     it('returns 500 internal_error when auditLog.create throws', async () => {
@@ -327,7 +406,9 @@ describe('DELETE /api/users/me', () => {
   describe('idempotency — second call after success', () => {
     it('first call returns 200; second call (now without a session) returns 401, not 500', async () => {
       // First call succeeds — session resolves to USER_ID.
-      mockAuth.mockResolvedValueOnce({ user: { id: USER_ID } });
+      mockAuth.mockResolvedValueOnce({
+        user: { id: USER_ID, authTime: recentAuthTime() },
+      });
       // Second call: NextAuth no longer resolves a user (the JWT-bound user
       // row is gone, so even if the cookie is replayed, session.user.id
       // returns undefined).

--- a/__tests__/lib/reauth.test.ts
+++ b/__tests__/lib/reauth.test.ts
@@ -1,0 +1,99 @@
+/**
+ * MYR-76: unit tests for the recent-login re-auth helper.
+ *
+ * The helper backs `DELETE /api/users/me` and `GET /api/users/me/export`
+ * (rest-api.md §7.6 / §7.7). End-to-end behavior is exercised in the
+ * route handler tests; these cases focus on the pure-function edges.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { isRecentlyAuthenticated, reauthMaxAgeSec } from '@/lib/reauth';
+
+const FIVE_MINUTES_SEC = 5 * 60;
+
+describe('reauthMaxAgeSec', () => {
+  const prev = process.env.REAUTH_MAX_AGE_SEC;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.REAUTH_MAX_AGE_SEC;
+    else process.env.REAUTH_MAX_AGE_SEC = prev;
+  });
+
+  it('defaults to 300 s when the env var is unset', () => {
+    delete process.env.REAUTH_MAX_AGE_SEC;
+    expect(reauthMaxAgeSec()).toBe(FIVE_MINUTES_SEC);
+  });
+
+  it('respects a positive integer override', () => {
+    process.env.REAUTH_MAX_AGE_SEC = '60';
+    expect(reauthMaxAgeSec()).toBe(60);
+  });
+
+  it('falls back to the default for non-numeric values', () => {
+    process.env.REAUTH_MAX_AGE_SEC = 'banana';
+    expect(reauthMaxAgeSec()).toBe(FIVE_MINUTES_SEC);
+  });
+
+  it('falls back to the default for zero', () => {
+    process.env.REAUTH_MAX_AGE_SEC = '0';
+    expect(reauthMaxAgeSec()).toBe(FIVE_MINUTES_SEC);
+  });
+
+  it('falls back to the default for negatives', () => {
+    process.env.REAUTH_MAX_AGE_SEC = '-30';
+    expect(reauthMaxAgeSec()).toBe(FIVE_MINUTES_SEC);
+  });
+
+  it('falls back to the default for an empty string', () => {
+    process.env.REAUTH_MAX_AGE_SEC = '';
+    expect(reauthMaxAgeSec()).toBe(FIVE_MINUTES_SEC);
+  });
+});
+
+describe('isRecentlyAuthenticated', () => {
+  // Pin "now" so the window math is deterministic across CI loads.
+  const NOW = 1_730_000_000;
+
+  it('returns false for missing authTime (legacy session)', () => {
+    expect(isRecentlyAuthenticated(undefined, NOW)).toBe(false);
+    expect(isRecentlyAuthenticated(null, NOW)).toBe(false);
+  });
+
+  it('returns true for an authTime exactly at now', () => {
+    expect(isRecentlyAuthenticated(NOW, NOW)).toBe(true);
+  });
+
+  it('returns true at the inclusive edge of the default window (now - 300 s)', () => {
+    expect(isRecentlyAuthenticated(NOW - FIVE_MINUTES_SEC, NOW)).toBe(true);
+  });
+
+  it('returns false one second past the edge', () => {
+    expect(isRecentlyAuthenticated(NOW - FIVE_MINUTES_SEC - 1, NOW)).toBe(
+      false,
+    );
+  });
+
+  it('returns false for a stale authTime well outside the window', () => {
+    expect(isRecentlyAuthenticated(NOW - 60 * 60, NOW)).toBe(false);
+  });
+
+  it('honors REAUTH_MAX_AGE_SEC override on the boundary check', () => {
+    const prev = process.env.REAUTH_MAX_AGE_SEC;
+    try {
+      process.env.REAUTH_MAX_AGE_SEC = '60';
+      // 90 s ago — passes the 300 s default but fails the 60 s override.
+      expect(isRecentlyAuthenticated(NOW - 90, NOW)).toBe(false);
+      expect(isRecentlyAuthenticated(NOW - 30, NOW)).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.REAUTH_MAX_AGE_SEC;
+      else process.env.REAUTH_MAX_AGE_SEC = prev;
+    }
+  });
+
+  it('treats a future authTime as recent (clock-skew tolerance)', () => {
+    // If the server clock skews behind the IdP clock, authTime can be in
+    // the future. The check is `now - authTime <= maxAge`, which is
+    // negative for future authTime — well within the window.
+    expect(isRecentlyAuthenticated(NOW + 30, NOW)).toBe(true);
+  });
+});

--- a/src/app/api/users/me/export/route.ts
+++ b/src/app/api/users/me/export/route.ts
@@ -33,6 +33,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { errorEnvelope } from '@/lib/api-errors';
 import { prisma } from '@/lib/prisma';
+import { isRecentlyAuthenticated } from '@/lib/reauth';
 
 import {
   mapAccountToExport,
@@ -52,6 +53,20 @@ export async function GET(): Promise<NextResponse> {
   if (!userId) {
     return NextResponse.json(
       errorEnvelope('auth_failed', 'authentication required'),
+      { status: 401 },
+    );
+  }
+
+  // MYR-76 recent-login re-auth gate (rest-api.md §7.7). Symmetric with
+  // §7.6 DELETE — both endpoints surface the full ownership graph; a
+  // stolen bearer token must not dump it without a fresh sign-in.
+  if (!isRecentlyAuthenticated(session.user.authTime)) {
+    return NextResponse.json(
+      errorEnvelope(
+        'auth_failed',
+        'recent re-authentication required',
+        'reauth_required',
+      ),
       { status: 401 },
     );
   }

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -26,6 +26,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { errorEnvelope } from '@/lib/api-errors';
 import { prisma } from '@/lib/prisma';
+import { isRecentlyAuthenticated } from '@/lib/reauth';
 
 export async function DELETE(): Promise<NextResponse> {
   const session = await auth();
@@ -34,6 +35,18 @@ export async function DELETE(): Promise<NextResponse> {
   if (!userId) {
     return NextResponse.json(
       errorEnvelope('auth_failed', 'authentication required'),
+      { status: 401 },
+    );
+  }
+
+  // MYR-76 recent-login re-auth gate (rest-api.md §7.6).
+  if (!isRecentlyAuthenticated(session.user.authTime)) {
+    return NextResponse.json(
+      errorEnvelope(
+        'auth_failed',
+        'recent re-authentication required',
+        'reauth_required',
+      ),
       { status: 401 },
     );
   }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -159,11 +159,22 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
           token.id = user.id;
         }
       }
+      // MYR-76 recent-login claim: stamp `authTime` whenever the user
+      // completes an OAuth round-trip. `account` is non-null only on the
+      // sign-in/link callback; subsequent refreshes leave the existing
+      // value intact so the recency window measures from the most recent
+      // fresh authentication, not session activity.
+      if (account) {
+        token.authTime = Math.floor(Date.now() / 1000);
+      }
       return token;
     },
     session({ session, token }) {
       if (session.user && token.id) {
         session.user.id = token.id as string;
+      }
+      if (session.user && typeof token.authTime === 'number') {
+        session.user.authTime = token.authTime;
       }
       return session;
     },

--- a/src/lib/reauth.ts
+++ b/src/lib/reauth.ts
@@ -1,0 +1,44 @@
+/**
+ * Recent-login re-auth gate (MYR-76).
+ *
+ * `DELETE /api/users/me` (rest-api.md §7.6) and `GET /api/users/me/export`
+ * (§7.7) require a session refreshed within the last N minutes on top of
+ * the standard Bearer-token check. Defends against stolen-token deletion
+ * and stolen-token bulk export per the GDPR Art. 17 recent-auth corollary.
+ *
+ * Mechanism: the NextAuth `jwt` callback stamps `token.authTime`
+ * (Unix-seconds, mirroring the OIDC `auth_time` claim) on every fresh
+ * sign-in — i.e., whenever the callback receives a non-null `account`.
+ * Subsequent JWT refreshes preserve the original value. The session
+ * callback forwards `authTime` to `session.user.authTime` so route
+ * handlers can check freshness without re-decoding the cookie.
+ */
+
+const FIVE_MINUTES_SEC = 5 * 60;
+
+/**
+ * Maximum age of the most-recent OAuth sign-in (in seconds) for the
+ * re-auth gate on destructive / bulk-export endpoints. Configurable via
+ * `REAUTH_MAX_AGE_SEC` for ops drills or test overrides; default 5 min
+ * matches the suggested value in MYR-76's scope.
+ */
+export function reauthMaxAgeSec(): number {
+  const raw = process.env.REAUTH_MAX_AGE_SEC;
+  if (!raw) return FIVE_MINUTES_SEC;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : FIVE_MINUTES_SEC;
+}
+
+/**
+ * Returns true when the session's `authTime` is within `reauthMaxAgeSec()`
+ * of now. A missing `authTime` (legacy session predating the JWT-claim
+ * rollout) is treated as stale — the user must re-sign-in to acquire the
+ * claim before the gated endpoints accept the request.
+ */
+export function isRecentlyAuthenticated(
+  authTime: number | null | undefined,
+  now: number = Math.floor(Date.now() / 1000),
+): boolean {
+  if (typeof authTime !== 'number') return false;
+  return now - authTime <= reauthMaxAgeSec();
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -8,6 +8,12 @@ declare module 'next-auth' {
       name?: string | null;
       email?: string | null;
       image?: string | null;
+      /**
+       * Unix seconds at most-recent OAuth sign-in. Mirrors the OIDC
+       * `auth_time` claim. Powers the recent-login re-auth gate on
+       * destructive / bulk-export endpoints (MYR-76, `src/lib/reauth.ts`).
+       */
+      authTime?: number;
     };
   }
 }
@@ -15,5 +21,7 @@ declare module 'next-auth' {
 declare module 'next-auth/jwt' {
   interface JWT {
     id?: string;
+    /** See Session.user.authTime — set on first JWT issuance, preserved on refresh. */
+    authTime?: number;
   }
 }


### PR DESCRIPTION
Handler implementation for the recent-login re-auth gate. Contract amendments ship separately in the telemetry repo as **[MYR-79](https://linear.app/myrobotaxi/issue/MYR-79)** ([tnando/my-robo-taxi-telemetry PR](https://github.com/tnando/my-robo-taxi-telemetry/pull/new/thomasnandola/myr-79-document-recent_login-re-auth-precondition-in-rest-apimd)) to satisfy the "one Linear issue per PR" rule.

## Summary

- `src/lib/reauth.ts` — new helper: `isRecentlyAuthenticated()` + `REAUTH_MAX_AGE_SEC` parser (default 300 s, configurable via env).
- `src/auth.ts` — NextAuth `jwt` callback stamps `token.authTime` (Unix seconds, OIDC-style `auth_time`) whenever a non-null `account` is present (fresh OAuth round-trip). The session callback forwards it to `session.user.authTime`. Refreshes preserve the existing value — recency measures from the most recent fresh sign-in, not from session activity.
- `src/app/api/users/me/route.ts` — precondition check before the deletion transaction; rejection returns `401 auth_failed` with `subCode: reauth_required` and the handler does NOT enter the cascade.
- `src/app/api/users/me/export/route.ts` — symmetric precondition, applied for the same reason: both endpoints surface the full ownership graph.
- `src/types/next-auth.d.ts` — augment `Session.user` and `JWT` with `authTime`.

## Why the gate applies symmetrically to export

GDPR Art. 17's recent-auth corollary — the right to erasure does not license unauthorized erasure — applies to **exfiltration** as well as deletion. Both `DELETE` and `GET /export` carry the full ownership graph (vehicles, drives, GPS trails, invites). A stolen Bearer token alone must not be sufficient to dump or destroy that graph; the user's most recent fresh OAuth sign-in is the auxiliary signal that the actor is the legitimate owner.

## Test plan

- [x] All 754 existing vitest tests pass locally (`npm test`)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean for new files (9 pre-existing warnings unchanged)
- [ ] CI vitest + typecheck + lint pass
- [ ] No frontend caller exists yet for `DELETE /api/users/me` (handler is currently API-only). When the UI is built, it should branch on `error.subCode === 'reauth_required'` and trigger `signIn()` with `callbackUrl=` pointing back at the gated action.

### New tests

| Test | What it covers |
|------|----------------|
| `authTime` missing → 401 reauth_required | Legacy sessions predating the JWT-claim rollout (and any session whose token didn't ride through a fresh OAuth) |
| stale `authTime` (10 min ago) → 401 reauth_required | The 5-min default window rejects expired recency |
| edge of window (5 min – 1 s) → 200 | Boundary condition |
| `REAUTH_MAX_AGE_SEC=60` override → 401 at 90 s | Ops can tighten the window via env |

Mirror tests in the export handler.

Relates: [MYR-79](https://linear.app/myrobotaxi/issue/MYR-79) (contract docs, telemetry repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)