### PR TITLE
infra: migrate Claude Review workflow to myrobotaxi-pr-review GitHub App

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -22,18 +22,30 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
     steps:
+      # Generate a short-lived (~1h) installation token from the
+      # `myrobotaxi-pr-review` GitHub App, owned by the org. App-issued
+      # tokens are accepted by branch protection's "required approving
+      # reviews" rule and the App identity does not consume a billable
+      # seat (replaces the previous tnando-gh-bot collaborator pattern).
+      - name: Generate App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.REVIEWER_APP_ID }}
+          private-key: ${{ secrets.REVIEWER_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Run Claude Code review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GH_PAT }}
+          github_token: ${{ steps.app-token.outputs.token }}
           use_sticky_comment: true
           track_progress: true
           show_full_output: true
@@ -127,39 +139,44 @@ jobs:
       - name: Submit PR review
         if: github.event_name == 'pull_request'
         shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
 
           # Read Claude's review comment (the one containing a Verdict)
-          COMMENT=$(GH_TOKEN=${{ secrets.GH_PAT }} gh pr view "$PR_NUMBER" \
+          COMMENT=$(gh pr view "$PR_NUMBER" \
             --json comments \
             --jq '[.comments[] | select(.body | test("Verdict"))] | last | .body')
 
           echo "Verdict line:"
           echo "$COMMENT" | grep -i "Verdict" || echo "(no verdict found)"
 
-          # BOT_PAT belongs to tnando-gh-bot (a separate collaborator with write access)
-          # so it can approve/request-changes on PRs authored by tnando.
+          # The App-issued installation token authors reviews as
+          # `myrobotaxi-pr-review[bot]`. App-bot reviews satisfy the
+          # "required approving reviews" branch-protection rule without
+          # consuming a paid org seat (replaces the prior tnando-gh-bot
+          # collaborator + BOT_PAT pattern).
           if echo "$COMMENT" | grep -qi 'Verdict' && echo "$COMMENT" | grep -qi '\bAPPROVE\b'; then
             echo "Submitting approval"
             # Dismiss any stale REQUEST_CHANGES review from the bot before approving
-            REVIEW_ID=$(GH_TOKEN=${{ secrets.BOT_PAT }} gh api \
+            REVIEW_ID=$(gh api \
               "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \
-              --jq '[.[] | select(.user.login == "tnando-gh-bot" and .state == "CHANGES_REQUESTED")] | last | .id' 2>/dev/null)
+              --jq '[.[] | select(.user.login == "myrobotaxi-pr-review[bot]" and .state == "CHANGES_REQUESTED")] | last | .id' 2>/dev/null)
             if [ -n "$REVIEW_ID" ] && [ "$REVIEW_ID" != "null" ]; then
               echo "Dismissing stale REQUEST_CHANGES review $REVIEW_ID"
-              GH_TOKEN=${{ secrets.BOT_PAT }} gh api \
+              gh api \
                 "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews/$REVIEW_ID/dismissals" \
                 -f message="Issues resolved — approving." || true
             fi
-            GH_TOKEN=${{ secrets.BOT_PAT }} gh pr review "$PR_NUMBER" --approve \
+            gh pr review "$PR_NUMBER" --approve \
               -b "Automated approval based on Claude Code review."
           elif echo "$COMMENT" | grep -qi 'Verdict' && echo "$COMMENT" | grep -qi '\bREQUEST_CHANGES\b'; then
             echo "Submitting request for changes"
-            GH_TOKEN=${{ secrets.BOT_PAT }} gh pr review "$PR_NUMBER" --request-changes \
+            gh pr review "$PR_NUMBER" --request-changes \
               -b "Changes requested based on Claude Code review."
           else
             echo "Submitting comment review"
-            GH_TOKEN=${{ secrets.BOT_PAT }} gh pr review "$PR_NUMBER" --comment \
+            gh pr review "$PR_NUMBER" --comment \
               -b "Review complete — see Claude's comment for details."
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,16 +153,16 @@ For behavioral changes (redirects, transitions, multi-step flows), also include 
 Since this repo is private, relative paths and `raw.githubusercontent.com` URLs do NOT work in PR descriptions. Use full blob URLs with `?raw=true`:
 
 ```markdown
-![Sign In](https://github.com/tnando/my-robo-taxi/blob/<branch>/screenshots/01-signin.png?raw=true)
+![Sign In](https://github.com/myrobotaxi/my-robo-taxi/blob/<branch>/screenshots/01-signin.png?raw=true)
 ```
 
 For video demos, use the same pattern (GitHub renders `.mp4` inline):
 
 ```markdown
-![Protected redirect](https://github.com/tnando/my-robo-taxi/blob/<branch>/demos/01-protected-redirect.gif?raw=true)
+![Protected redirect](https://github.com/myrobotaxi/my-robo-taxi/blob/<branch>/demos/01-protected-redirect.gif?raw=true)
 ```
 
-The pattern is: `https://github.com/tnando/my-robo-taxi/blob/<branch>/<path>?raw=true`
+The pattern is: `https://github.com/myrobotaxi/my-robo-taxi/blob/<branch>/<path>?raw=true`
 
 Replace `<branch>` with the PR branch name (e.g., `feature/frontend-ui`).
 


### PR DESCRIPTION
## Summary

Mirrors the same change landing in the [telemetry repo](https://github.com/myrobotaxi/my-robo-taxi-telemetry/pull/229): swaps the Claude Review workflow off `GH_PAT` + `BOT_PAT` (personal access tokens of `tnando` + `tnando-gh-bot`) onto short-lived installation tokens from the new `myrobotaxi-pr-review` GitHub App owned by the org.

## Why

- **App reviews satisfy branch protection's "required approving reviews" rule** — same gate strength as a human approval, no `tnando-gh-bot` collaborator needed.
- **No billable org seat consumed** — saves $4/mo and removes the per-repo collaborator management overhead.
- **Org-level secret + variable** — every repo in `myrobotaxi` inherits the same credentials. Rotating is a single `gh secret set --org` command.

## Required org-level credentials (already configured)

| Type | Name |
|---|---|
| Variable | `REVIEWER_APP_ID` |
| Secret | `REVIEWER_APP_PRIVATE_KEY` |
| Secret | `CLAUDE_CODE_OAUTH_TOKEN` |

## Changes

- `.github/workflows/code-review.yml`:
  - Generates App installation token via `actions/create-github-app-token@v1` before checkout.
  - Replaces `GH_PAT` (in `checkout.token` + `claude-code-action.github_token` + verdict-fetch `gh pr view`).
  - Replaces `BOT_PAT` (in the verdict-submission `gh pr review` + stale-review-dismissal logic).
  - Updates the stale-review-dismissal selector to look for `myrobotaxi-pr-review[bot]` instead of `tnando-gh-bot`.
- `CLAUDE.md`: bumps 3 `tnando/my-robo-taxi` → `myrobotaxi/my-robo-taxi` URLs in the "Linking Media in PR Descriptions" examples.

## Cleanup follow-ups (deferred)

- `GH_PAT` and `BOT_PAT` secrets on this repo can be retired after the next Claude Review fires successfully under the new App identity.
- `tnando-gh-bot` collaborator can be removed from this repo.

## Test plan

- [ ] CI's existing jobs (lint/e2e/etc.) pass — unchanged
- [ ] `Claude Review` posts under the `myrobotaxi-pr-review[bot]` identity on this PR
- [ ] Verdict-submission step approves/requests-changes/comments under the bot identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)