### PR TITLE
MYR-94 Sweep cross-repo refs after react-frontend rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,16 +153,16 @@ For behavioral changes (redirects, transitions, multi-step flows), also include 
 Since this repo is private, relative paths and `raw.githubusercontent.com` URLs do NOT work in PR descriptions. Use full blob URLs with `?raw=true`:
 
 ```markdown
-![Sign In](https://github.com/myrobotaxi/my-robo-taxi/blob/<branch>/screenshots/01-signin.png?raw=true)
+![Sign In](https://github.com/myrobotaxi/react-frontend/blob/<branch>/screenshots/01-signin.png?raw=true)
 ```
 
 For video demos, use the same pattern (GitHub renders `.mp4` inline):
 
 ```markdown
-![Protected redirect](https://github.com/myrobotaxi/my-robo-taxi/blob/<branch>/demos/01-protected-redirect.gif?raw=true)
+![Protected redirect](https://github.com/myrobotaxi/react-frontend/blob/<branch>/demos/01-protected-redirect.gif?raw=true)
 ```
 
-The pattern is: `https://github.com/myrobotaxi/my-robo-taxi/blob/<branch>/<path>?raw=true`
+The pattern is: `https://github.com/myrobotaxi/react-frontend/blob/<branch>/<path>?raw=true`
 
 Replace `<branch>` with the PR branch name (e.g., `feature/frontend-ui`).
 

--- a/agents/backend-agent.md
+++ b/agents/backend-agent.md
@@ -68,7 +68,7 @@ Implement these models:
 - Do NOT modify frontend pages or components — that's the Frontend Agent's job
 
 ## Project Context
-- **Repo:** `/Users/thomasnandola/github/claude-apps/my-robo-taxi`
+- **Repo:** `/Users/thomasnandola/github/claude-apps/react-frontend`
 - **Database:** PostgreSQL via Supabase
 - **MQTT Broker:** HiveMQ Cloud (free tier)
 - **Deployment target:** Vercel (consider serverless limitations for WebSocket/MQTT)

--- a/agents/coordinator-agent.md
+++ b/agents/coordinator-agent.md
@@ -35,7 +35,7 @@ You are the Coordinator Agent for the MyRoboTaxi project. You orchestrate the en
 - If an agent fails or produces incomplete output, report the issue and ask for guidance
 
 ## Project Context
-- **Repo:** `/Users/thomasnandola/github/claude-apps/my-robo-taxi`
+- **Repo:** `/Users/thomasnandola/github/claude-apps/react-frontend`
 - **Tech stack:** Next.js 14 (App Router), TypeScript, Tailwind, Prisma, Supabase, Mapbox, MQTT, NextAuth
 - **v1 scope:** Owner onboarding, invite system, live dashboard, FSD tracking, drive summaries
 - **Deferred to v2:** Ride request feature

--- a/agents/frontend-agent.md
+++ b/agents/frontend-agent.md
@@ -379,7 +379,7 @@ Aim to commit every **15-30 minutes of active work**, or whenever a logical unit
 
 ## Project Context
 
-- **Repo:** `/Users/thomasnandola/github/claude-apps/my-robo-taxi`
+- **Repo:** `/Users/thomasnandola/github/claude-apps/react-frontend`
 - **Source:** `src/` directory (Next.js app)
 - **Mocks:** `ui-mocks/` directory (Vite + React reference implementation)
 - **Architecture:** `docs/design/frontend-architecture.md`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "my-robo-taxi",
+  "name": "react-frontend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-robo-taxi",
+      "name": "react-frontend",
       "version": "0.1.0",
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-robo-taxi",
+  "name": "react-frontend",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/lib/cryptox/__fixtures__/README.md
+++ b/src/lib/cryptox/__fixtures__/README.md
@@ -3,10 +3,10 @@
 `cross-impl.json` is a fixed AES-256-GCM ciphertext, key, and plaintext
 triple used by the cryptox unit tests on **both** implementations:
 
-- **TS (this repo, my-robo-taxi):** `__tests__/lib/cryptox/encryptor.test.ts`
+- **TS (this repo, react-frontend):** `__tests__/lib/cryptox/encryptor.test.ts`
   loads it and asserts `decryptString(ciphertext_b64)` round-trips to
   `plaintext` under `key_b64`.
-- **Go (my-robo-taxi-telemetry, Phase 2):**
+- **Go (telemetry, Phase 2):**
   `internal/cryptox/testdata/cross-impl.json` will hold an
   identical-content copy with the same SHA256, exercising the same
   decrypt assertion.

--- a/src/lib/cryptox/encryptor.ts
+++ b/src/lib/cryptox/encryptor.ts
@@ -3,7 +3,7 @@
  * data classified per docs/contracts/data-classification.md §3.3.
  *
  * This is the TypeScript port of the Go-side `internal/cryptox` package
- * (my-robo-taxi-telemetry). The wire format is byte-equal across
+ * (telemetry). The wire format is byte-equal across
  * implementations so a row encrypted by either side is decryptable by
  * the other:
  *

--- a/src/lib/route-blob-encryption.ts
+++ b/src/lib/route-blob-encryption.ts
@@ -30,7 +30,7 @@
  *
  * Rollout phases mirror MYR-62 / MYR-63:
  *   1. Dual-write (this PR — TS Phase 1)
- *   2. Phase 2 — Go telemetry pipeline (separate, my-robo-taxi-telemetry)
+ *   2. Phase 2 — Go telemetry pipeline (separate, telemetry)
  *   3. Backfill — separate post-rollout issue
  *   4. Read-flip — separate post-rollout issue
  *   5. Drop plaintext columns — separate post-rollout issue


### PR DESCRIPTION
## Summary

Updates 9 files to reflect the org-wide repo renames (MYR-94):

- `my-robo-taxi-telemetry` → `telemetry` (3 occurrences)
- Standalone `my-robo-taxi` → `react-frontend` (8 occurrences; this repo's new name)
- `my-robo-taxi-test-bench` / `-testbench` preserved

Touches: `package.json` (root name), `package-lock.json` (name-only, no dep churn), `CLAUDE.md`, `agents/{backend,coordinator,frontend}-agent.md`, `src/lib/route-blob-encryption.ts` (comment), `src/lib/cryptox/encryptor.ts` (comment), `src/lib/cryptox/__fixtures__/README.md`.

All non-metadata edits are in comments — code logic is untouched.

## Test plan

- [ ] CI green
- [ ] Linear MYR-94 ticket reflects all 3 sweep PRs merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)